### PR TITLE
feat(task): add `task::Builder`

### DIFF
--- a/madsim/src/sim/net/mod.rs
+++ b/madsim/src/sim/net/mod.rs
@@ -48,7 +48,7 @@ use tracing::*;
 use crate::{
     plugin,
     rand::{GlobalRng, Rng},
-    task::{NodeId, TaskNodeHandle},
+    task::{NodeId, Spawner},
     time::{Duration, TimeHandle},
 };
 
@@ -79,7 +79,7 @@ pub struct NetSim {
     network: Mutex<Network>,
     rand: GlobalRng,
     time: TimeHandle,
-    task: TaskNodeHandle,
+    task: Spawner,
 }
 
 /// Message sent to a network socket.
@@ -93,12 +93,7 @@ impl plugin::Simulator for NetSim {
         unreachable!()
     }
 
-    fn new1(
-        rand: &GlobalRng,
-        time: &TimeHandle,
-        task: &TaskNodeHandle,
-        config: &crate::Config,
-    ) -> Self {
+    fn new1(rand: &GlobalRng, time: &TimeHandle, task: &Spawner, config: &crate::Config) -> Self {
         NetSim {
             network: Mutex::new(Network::new(rand.clone(), config.net.clone())),
             rand: rand.clone(),

--- a/madsim/src/sim/plugin.rs
+++ b/madsim/src/sim/plugin.rs
@@ -9,7 +9,7 @@ use downcast_rs::{impl_downcast, DowncastSync};
 
 use crate::{
     rand::GlobalRng,
-    task::{NodeId, TaskNodeHandle},
+    task::{NodeId, Spawner},
     time::TimeHandle,
     Config,
 };
@@ -25,7 +25,7 @@ pub trait Simulator: Any + Send + Sync + DowncastSync {
 
     // XXX: For compatibility. Merge to `new` in the next major version.
     #[doc(hidden)]
-    fn new1(rand: &GlobalRng, time: &TimeHandle, _task: &TaskNodeHandle, config: &Config) -> Self
+    fn new1(rand: &GlobalRng, time: &TimeHandle, _task: &Spawner, config: &Config) -> Self
     where
         Self: Sized,
     {

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -345,10 +345,10 @@ impl<'a> NodeBuilder<'a> {
         let sims = self.handle.sims.lock();
         let values = sims.values();
         for sim in values {
-            sim.create_node(task.id());
+            sim.create_node(task.node_id());
             if let Some(ip) = self.ip {
                 if let Some(net) = sim.downcast_ref::<net::NetSim>() {
-                    net.set_ip(task.id(), ip)
+                    net.set_ip(task.node_id(), ip)
                 }
             }
         }
@@ -359,13 +359,13 @@ impl<'a> NodeBuilder<'a> {
 /// Handle to a node.
 #[derive(Clone)]
 pub struct NodeHandle {
-    task: task::TaskNodeHandle,
+    task: task::Spawner,
 }
 
 impl NodeHandle {
     /// Returns the node ID.
     pub fn id(&self) -> NodeId {
-        self.task.id()
+        self.task.node_id()
     }
 
     /// Spawn a future onto the runtime.

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -1,7 +1,7 @@
 //! The madsim runtime.
 
 use super::*;
-use crate::task::{JoinHandle, NodeId};
+use crate::task::{JoinHandle, NodeId, ToNodeId};
 use spin::Mutex;
 use std::{
     any::{Any, TypeId},
@@ -238,8 +238,9 @@ impl Handle {
     ///
     /// - All tasks spawned on this node will be killed immediately.
     /// - All data that has not been flushed to the disk will be lost.
-    pub fn kill(&self, id: NodeId) {
-        self.task.kill(id);
+    pub fn kill(&self, id: impl ToNodeId) {
+        self.task.kill(&id);
+        let id = id.to_node_id(&self.task);
         let sims = self.sims.lock();
         let values = sims.values();
         for sim in values {
@@ -248,8 +249,9 @@ impl Handle {
     }
 
     /// Restart a node。
-    pub fn restart(&self, id: NodeId) {
-        self.task.restart(id);
+    pub fn restart(&self, id: impl ToNodeId) {
+        self.task.restart(&id);
+        let id = id.to_node_id(&self.task);
         let sims = self.sims.lock();
         let values = sims.values();
         for sim in values {
@@ -258,12 +260,12 @@ impl Handle {
     }
 
     /// Pause the execution of a node.
-    pub fn pause(&self, id: NodeId) {
+    pub fn pause(&self, id: impl ToNodeId) {
         self.task.pause(id);
     }
 
     /// Resume the execution of a node.
-    pub fn resume(&self, id: NodeId) {
+    pub fn resume(&self, id: impl ToNodeId) {
         self.task.resume(id);
     }
 
@@ -273,7 +275,7 @@ impl Handle {
     }
 
     /// Return a handle of the specified node.
-    pub fn get_node(&self, id: NodeId) -> Option<NodeHandle> {
+    pub fn get_node(&self, id: impl ToNodeId) -> Option<NodeHandle> {
         self.task.get_node(id).map(|task| NodeHandle { task })
     }
 }

--- a/madsim/src/sim/task.rs
+++ b/madsim/src/sim/task.rs
@@ -361,7 +361,7 @@ pub struct Spawner {
 }
 
 /// A handle to spawn tasks on a node.
-#[deprecated(since = "0.3", note = "use Spawner instead")]
+#[deprecated(since = "0.3.0", note = "use Spawner instead")]
 pub type TaskNodeHandle = Spawner;
 
 impl Spawner {
@@ -445,7 +445,10 @@ where
 }
 
 /// Runs the provided closure on a thread where blocking is acceptable.
-#[deprecated(since = "0.3", note = "blocking function is not allowed in simulation")]
+#[deprecated(
+    since = "0.3.0",
+    note = "blocking function is not allowed in simulation"
+)]
 #[track_caller]
 pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
 where

--- a/madsim/src/sim/task.rs
+++ b/madsim/src/sim/task.rs
@@ -386,6 +386,7 @@ where
 }
 
 /// Runs the provided closure on a thread where blocking is acceptable.
+#[deprecated(since = "0.3", note = "blocking function is not allowed in simulation")]
 pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
 where
     F: FnOnce() -> R + Send + 'static,


### PR DESCRIPTION
- deprecate `spawn_blocking`
- panic on DNS lookup
- accept name as the argument of node ctl functions
- rename `TaskNodeHandle` to `Spawner` and deprecate the former
- add tokio unstable `task::Builder` API