### PR TITLE
fix(net): avoid closing the socket of restarted node

### DIFF
--- a/madsim-tonic/src/transport/server.rs
+++ b/madsim-tonic/src/transport/server.rs
@@ -244,15 +244,17 @@ impl<L> Router<L> {
             madsim::task::spawn(async move {
                 let mut stream = rsp_future.instrument(span.clone()).await.unwrap();
                 // send the response
+                let mut count = 0;
                 while let Some(rsp) = stream.next().await {
                     // rsp: Result<BoxMessage, Status>
                     let res = tx.send(Box::new(rsp)).await;
                     if res.is_err() {
                         // client has closed the stream
-                        return;
+                        break;
                     }
+                    count += 1;
                 }
-                debug!(parent: &span, "completed");
+                debug!(parent: &span, "completed {count}");
             });
         }
     }

--- a/madsim-tonic/src/transport/server.rs
+++ b/madsim-tonic/src/transport/server.rs
@@ -220,7 +220,7 @@ impl<L> Router<L> {
                 .downcast::<(PathAndQuery, BoxMessage)>()
                 .expect("invalid type");
             let span = debug_span!("request", ?addr, ?path);
-            debug!(parent: &span, "received request");
+            debug!(parent: &span, "received");
 
             let requests: BoxMessageStream = if msg.downcast_ref::<()>().is_none() {
                 // single request
@@ -242,7 +242,7 @@ impl<L> Router<L> {
             poll_fn(|cx| svc.poll_ready(cx)).await.unwrap();
             let rsp_future = svc.call((addr, path, requests));
             madsim::task::spawn(async move {
-                let mut stream = rsp_future.instrument(span).await.unwrap();
+                let mut stream = rsp_future.instrument(span.clone()).await.unwrap();
                 // send the response
                 while let Some(rsp) = stream.next().await {
                     // rsp: Result<BoxMessage, Status>
@@ -252,6 +252,7 @@ impl<L> Router<L> {
                         return;
                     }
                 }
+                debug!(parent: &span, "completed");
             });
         }
     }

--- a/madsim/src/sim/net/endpoint.rs
+++ b/madsim/src/sim/net/endpoint.rs
@@ -114,7 +114,7 @@ impl Endpoint {
         self.guard
             .net
             .send(
-                self.guard.node,
+                self.guard.node.id,
                 self.guard.addr.port(),
                 dst,
                 Udp,
@@ -171,7 +171,7 @@ impl Endpoint {
         let (tx, rx, _) = self
             .guard
             .net
-            .connect1(self.guard.node, self.guard.addr.port(), addr, Udp)
+            .connect1(self.guard.node.id, self.guard.addr.port(), addr, Udp)
             .await?;
         let sender = Sender {
             _guard: self.guard.clone(),

--- a/madsim/src/sim/runtime/builder.rs
+++ b/madsim/src/sim/runtime/builder.rs
@@ -61,7 +61,7 @@ impl Builder {
             SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
-                .as_secs()
+                .as_nanos() as _
         };
         let jobs: u16 = if let Ok(jobs_str) = std::env::var("MADSIM_TEST_JOBS") {
             jobs_str

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -306,7 +306,7 @@ impl<'a> NodeBuilder<'a> {
     /// Set the initial task for the node.
     ///
     /// This task will be respawned when calling `restart`.
-    pub fn init<F>(mut self, future: impl Fn() -> F + 'static) -> Self
+    pub fn init<F>(mut self, future: impl Fn() -> F + Send + Sync + 'static) -> Self
     where
         F: Future + 'static,
     {

--- a/madsim/src/sim/task.rs
+++ b/madsim/src/sim/task.rs
@@ -184,8 +184,18 @@ impl Executor {
                     std::panic::catch_unwind(move || runnable.run())
                 };
                 if res.is_err() {
-                    error!("task panicked, restarting node");
-                    self.restart(node_id);
+                    let delay = self.rand.with(|rng| {
+                        rng.gen_range(Duration::from_secs(1)..Duration::from_secs(10))
+                    });
+                    error!(
+                        "task panicked, restarting node {} after {:?}",
+                        node_id, delay
+                    );
+                    self.kill(node_id);
+                    let h = self.handle.clone();
+                    self.time
+                        .handle()
+                        .add_timer(delay, move || h.restart(node_id));
                 }
             } else {
                 let _guard = crate::context::enter_task(info);
@@ -225,7 +235,7 @@ struct Node {
     init: Option<InitFn>,
 }
 
-pub(crate) type InitFn = Arc<dyn Fn(&Spawner)>;
+pub(crate) type InitFn = Arc<dyn Fn(&Spawner) + Send + Sync>;
 
 impl TaskHandle {
     /// Kill all tasks of the node.

--- a/madsim/src/sim/task.rs
+++ b/madsim/src/sim/task.rs
@@ -841,7 +841,7 @@ mod tests {
             .build();
 
         runtime.block_on(async move {
-            time::sleep(Duration::from_secs(10)).await;
+            time::sleep(Duration::from_secs(60)).await;
             // should panic 3 times and success once
             assert_eq!(flag.load(Ordering::Relaxed), 4);
         });

--- a/madsim/src/sim/task.rs
+++ b/madsim/src/sim/task.rs
@@ -91,6 +91,10 @@ impl NodeInfo {
             node: self.clone(),
         })
     }
+
+    pub(crate) fn is_killed(&self) -> bool {
+        self.killed.load(Ordering::Relaxed)
+    }
 }
 
 impl Executor {
@@ -184,9 +188,9 @@ impl Executor {
                     std::panic::catch_unwind(move || runnable.run())
                 };
                 if res.is_err() {
-                    let delay = self.rand.with(|rng| {
-                        rng.gen_range(Duration::from_secs(1)..Duration::from_secs(10))
-                    });
+                    let delay = self
+                        .rand
+                        .with(|rng| rng.gen_range(Duration::from_secs(1)..Duration::from_secs(10)));
                     error!(
                         "task panicked, restarting node {} after {:?}",
                         node_id, delay


### PR DESCRIPTION
- change the default seed to the **nanosecond** of current time
- wait for a while after panicking before restart
- tonic: log on request start and end