### PR TITLE
fix(time): fix panic cause by std internal structure change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        toolchain: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -76,7 +77,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
       - name: Test std
         uses: actions-rs/cargo@v1
         with:
@@ -87,6 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        toolchain: [stable, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -97,7 +99,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
       - name: Test sim
         uses: actions-rs/cargo@v1
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2022-10-28
+
+### Fixed
+
+- madsim: Fix internal structure change of nightly `std::time::{SystemTime, Interval}`.
+
 ## [0.2.8] - 2022-09-26
 
 ### Added

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Deterministic Simulator for distributed systems."

--- a/madsim/src/sim/time/system_time.rs
+++ b/madsim/src/sim/time/system_time.rs
@@ -47,7 +47,12 @@ unsafe extern "C" fn clock_gettime(
         // inside a madsim context, use the simulated time.
         match clockid {
             // used by SystemTime
-            libc::CLOCK_REALTIME | libc::CLOCK_REALTIME_COARSE => {
+            libc::CLOCK_REALTIME
+            | libc::CLOCK_REALTIME_COARSE
+            // used by Instant
+            | libc::CLOCK_MONOTONIC
+            | libc::CLOCK_MONOTONIC_RAW
+            | libc::CLOCK_MONOTONIC_COARSE => {
                 let dur = time
                     .now_time()
                     .duration_since(std::time::SystemTime::UNIX_EPOCH)
@@ -56,10 +61,6 @@ unsafe extern "C" fn clock_gettime(
                     tv_sec: dur.as_secs() as _,
                     tv_nsec: dur.subsec_nanos() as _,
                 });
-            }
-            // used by Instant
-            libc::CLOCK_MONOTONIC | libc::CLOCK_MONOTONIC_RAW | libc::CLOCK_MONOTONIC_COARSE => {
-                tp.write(std::mem::transmute(time.now_instant()));
             }
             _ => panic!("unsupported clockid: {}", clockid),
         }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/102368 (nightly-2022-09-29) changed the memory layout of `std::time::{SystemTime, Instant}` on Linux ([code](https://github.com/rust-lang/rust/commit/a91327782906885ccd8b8bf25e1e7f9ea46f8428#diff-3183738c82f747fd92bb573712073aa384b16e14d154bf2df18f41077edc31cbR23)), making them no longer equal to [libc::timespec](https://docs.rs/libc/latest/libc/struct.timespec.html#). So the previous transmute between these types will break data and trigger a panic.

This PR also releases v0.2.9.