### PR TITLE
fix(runtime): fix panic on TLS access error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2022-11-09
+
+### Fixed
+
+- madsim: Fix panic on TLS access error.
+
 ## [0.2.9] - 2022-10-28
 
 ### Fixed

--- a/madsim-rdkafka/src/std/mod.rs
+++ b/madsim-rdkafka/src/std/mod.rs
@@ -259,6 +259,7 @@
 
 #![forbid(missing_docs)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::all)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use rdkafka_sys::types;

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Deterministic Simulator for distributed systems."

--- a/madsim/src/sim/runtime/context.rs
+++ b/madsim/src/sim/runtime/context.rs
@@ -16,7 +16,11 @@ pub(crate) fn current<T>(map: impl FnOnce(&Handle) -> T) -> T {
 }
 
 pub(crate) fn try_current<T>(map: impl FnOnce(&Handle) -> T) -> Option<T> {
-    CONTEXT.with(move |ctx| ctx.borrow().as_ref().map(map))
+    // note: TLS may be deallocated
+    CONTEXT
+        .try_with(move |ctx| ctx.borrow().as_ref().map(map))
+        .ok()
+        .flatten()
 }
 
 pub(crate) fn current_task() -> Arc<TaskInfo> {
@@ -24,7 +28,7 @@ pub(crate) fn current_task() -> Arc<TaskInfo> {
 }
 
 pub(crate) fn try_current_task() -> Option<Arc<TaskInfo>> {
-    TASK.with(|task| task.borrow().clone())
+    TASK.try_with(|task| task.borrow().clone()).ok().flatten()
 }
 
 pub(crate) fn current_node() -> NodeId {


### PR DESCRIPTION
This PR fixes the panic on TLS access when getting time at the exit phase.

Also bumps version to 0.2.10.