### PR TITLE
feat(etcd): support load and dump

### DIFF
--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 madsim = { version = "0.2.8", path = "../madsim" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-hex = { version = "0.4", features = ["serde"] }
 spin = "0.9"
+thiserror = "1"
 tonic = { version = "0.8", default-features = false }
 tracing = "0.1"

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 madsim = { version = "0.2.8", path = "../madsim" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_with = { version = "2.1", features = ["hex"] }
+hex = { version = "0.4", features = ["serde"] }
 spin = "0.9"
 tonic = { version = "0.8", default-features = false }
 tracing = "0.1"

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -20,6 +20,9 @@ etcd-client = "0.10"
 http = "0.2"
 futures-util = "0.3"
 madsim = { version = "0.2.8", path = "../madsim" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_with = { version = "2.1", features = ["hex"] }
 spin = "0.9"
 tonic = { version = "0.8", default-features = false }
 tracing = "0.1"

--- a/madsim-etcd-client/src/bytes.rs
+++ b/madsim-etcd-client/src/bytes.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::ops::{Deref, DerefMut};
+
+/// A wrapper over `Vec<u8>` to represent bytes.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Bytes(#[serde(with = "hex::serde")] Vec<u8>);
+
+impl Bytes {
+    pub const fn new() -> Self {
+        Bytes(Vec::new())
+    }
+}
+
+impl Debug for Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", String::from_utf8_lossy(&self.0))
+    }
+}
+
+impl Deref for Bytes {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Bytes {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Vec<u8>> for Bytes {
+    fn from(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+}

--- a/madsim-etcd-client/src/election.rs
+++ b/madsim-etcd-client/src/election.rs
@@ -1,4 +1,4 @@
-use super::{server::Request, KeyValue, ResponseHeader, Result};
+use super::{server::Request, Bytes, KeyValue, ResponseHeader, Result};
 use futures_util::stream::{Stream, StreamExt};
 use madsim::net::{Endpoint, Receiver};
 use std::{
@@ -34,8 +34,8 @@ impl ElectionClient {
         lease: i64,
     ) -> Result<CampaignResponse> {
         let req = Request::Campaign {
-            name: name.into(),
-            value: value.into(),
+            name: name.into().into(),
+            value: value.into().into(),
             lease,
         };
         let (tx, mut rx) = self.ep.connect1(self.server_addr).await?;
@@ -55,7 +55,7 @@ impl ElectionClient {
                 .expect("no leader key")
                 .leader
                 .expect("no leader key"),
-            value: value.into(),
+            value: value.into().into(),
         };
         let (tx, mut rx) = self.ep.connect1(self.server_addr).await?;
         tx.send(Box::new(req)).await?;
@@ -65,7 +65,9 @@ impl ElectionClient {
     /// Returns the leader value for the current election.
     #[inline]
     pub async fn leader(&mut self, name: impl Into<Vec<u8>>) -> Result<LeaderResponse> {
-        let req = Request::Leader { name: name.into() };
+        let req = Request::Leader {
+            name: name.into().into(),
+        };
         let (tx, mut rx) = self.ep.connect1(self.server_addr).await?;
         tx.send(Box::new(req)).await?;
         *rx.recv().await?.downcast().unwrap()
@@ -75,7 +77,9 @@ impl ElectionClient {
     /// as GetResponse values on every current elected leader key.
     #[inline]
     pub async fn observe(&mut self, name: impl Into<Vec<u8>>) -> Result<ObserveStream> {
-        let req = Request::Observe { name: name.into() };
+        let req = Request::Observe {
+            name: name.into().into(),
+        };
         let (tx, rx) = self.ep.connect1(self.server_addr).await?;
         tx.send(Box::new(req)).await?;
         Ok(ObserveStream { rx })
@@ -140,8 +144,8 @@ impl ProclaimOptions {
 /// Leader key of election
 #[derive(Debug, Clone)]
 pub struct LeaderKey {
-    pub(crate) name: Vec<u8>,
-    pub(crate) key: Vec<u8>,
+    pub(crate) name: Bytes,
+    pub(crate) key: Bytes,
     pub(crate) rev: i64,
     pub(crate) lease: i64,
 }
@@ -151,8 +155,8 @@ impl LeaderKey {
     #[inline]
     pub const fn new() -> Self {
         Self {
-            name: Vec::new(),
-            key: Vec::new(),
+            name: Bytes::new(),
+            key: Bytes::new(),
             rev: 0,
             lease: 0,
         }
@@ -161,14 +165,14 @@ impl LeaderKey {
     /// The election identifier that corresponds to the leadership key.
     #[inline]
     pub fn with_name(mut self, name: impl Into<Vec<u8>>) -> Self {
-        self.name = name.into();
+        self.name = name.into().into();
         self
     }
 
     /// An opaque key representing the ownership of the election.
     #[inline]
     pub fn with_key(mut self, key: impl Into<Vec<u8>>) -> Self {
-        self.key = key.into();
+        self.key = key.into().into();
         self
     }
 

--- a/madsim-etcd-client/src/kv.rs
+++ b/madsim-etcd-client/src/kv.rs
@@ -1,4 +1,4 @@
-use super::{server::Request, ResponseHeader, Result};
+use super::{server::Request, Bytes, ResponseHeader, Result};
 use madsim::net::Endpoint;
 use std::{fmt::Display, net::SocketAddr};
 
@@ -29,8 +29,8 @@ impl KvClient {
         options: Option<PutOptions>,
     ) -> Result<PutResponse> {
         let req = Request::Put {
-            key: key.into(),
-            value: value.into(),
+            key: key.into().into(),
+            value: value.into().into(),
             options: options.unwrap_or_default(),
         };
         let (tx, mut rx) = self.ep.connect1(self.server_addr).await?;
@@ -46,7 +46,7 @@ impl KvClient {
         options: Option<GetOptions>,
     ) -> Result<GetResponse> {
         let req = Request::Get {
-            key: key.into(),
+            key: key.into().into(),
             options: options.unwrap_or_default(),
         };
         let (tx, mut rx) = self.ep.connect1(self.server_addr).await?;
@@ -62,7 +62,7 @@ impl KvClient {
         options: Option<DeleteOptions>,
     ) -> Result<DeleteResponse> {
         let req = Request::Delete {
-            key: key.into(),
+            key: key.into().into(),
             options: options.unwrap_or_default(),
         };
         let (tx, mut rx) = self.ep.connect1(self.server_addr).await?;
@@ -277,7 +277,7 @@ impl Txn {
         assert!(!self.c_else, "cannot call when after or_else");
 
         self.c_when = true;
-        self.compare = compares.into();
+        self.compare = compares.into().into();
         self
     }
 
@@ -289,7 +289,7 @@ impl Txn {
         assert!(!self.c_else, "cannot call and_then after or_else");
 
         self.c_then = true;
-        self.success = operations.into();
+        self.success = operations.into().into();
         self
     }
 
@@ -300,7 +300,7 @@ impl Txn {
         assert!(!self.c_else, "cannot call or_else twice");
 
         self.c_else = true;
-        self.failure = operations.into();
+        self.failure = operations.into().into();
         self
     }
 }
@@ -308,8 +308,8 @@ impl Txn {
 /// Transaction comparision.
 #[derive(Debug, Clone)]
 pub struct Compare {
-    pub(crate) key: Vec<u8>,
-    pub(crate) value: Vec<u8>,
+    pub(crate) key: Bytes,
+    pub(crate) value: Bytes,
     pub(crate) op: CompareOp,
 }
 
@@ -328,8 +328,8 @@ impl Compare {
     #[inline]
     pub fn value(key: impl Into<Vec<u8>>, cmp: CompareOp, value: impl Into<Vec<u8>>) -> Self {
         Compare {
-            key: key.into(),
-            value: value.into(),
+            key: key.into().into(),
+            value: value.into().into(),
             op: cmp,
         }
     }
@@ -339,16 +339,16 @@ impl Compare {
 #[derive(Debug, Clone)]
 pub enum TxnOp {
     Put {
-        key: Vec<u8>,
-        value: Vec<u8>,
+        key: Bytes,
+        value: Bytes,
         options: PutOptions,
     },
     Get {
-        key: Vec<u8>,
+        key: Bytes,
         options: GetOptions,
     },
     Delete {
-        key: Vec<u8>,
+        key: Bytes,
         options: DeleteOptions,
     },
     Txn {
@@ -365,8 +365,8 @@ impl TxnOp {
         options: Option<PutOptions>,
     ) -> Self {
         TxnOp::Put {
-            key: key.into(),
-            value: value.into(),
+            key: key.into().into(),
+            value: value.into().into(),
             options: options.unwrap_or_default(),
         }
     }
@@ -375,7 +375,7 @@ impl TxnOp {
     #[inline]
     pub fn get(key: impl Into<Vec<u8>>, options: Option<GetOptions>) -> Self {
         TxnOp::Get {
-            key: key.into(),
+            key: key.into().into(),
             options: options.unwrap_or_default(),
         }
     }
@@ -384,7 +384,7 @@ impl TxnOp {
     #[inline]
     pub fn delete(key: impl Into<Vec<u8>>, options: Option<DeleteOptions>) -> Self {
         TxnOp::Delete {
-            key: key.into(),
+            key: key.into().into(),
             options: options.unwrap_or_default(),
         }
     }
@@ -486,8 +486,8 @@ impl TxnResponse {
 /// Key-value pair.
 #[derive(Debug, Clone)]
 pub struct KeyValue {
-    pub(crate) key: Vec<u8>,
-    pub(crate) value: Vec<u8>,
+    pub(crate) key: Bytes,
+    pub(crate) value: Bytes,
 }
 
 impl KeyValue {

--- a/madsim-etcd-client/src/kv.rs
+++ b/madsim-etcd-client/src/kv.rs
@@ -277,7 +277,7 @@ impl Txn {
         assert!(!self.c_else, "cannot call when after or_else");
 
         self.c_when = true;
-        self.compare = compares.into().into();
+        self.compare = compares.into();
         self
     }
 
@@ -289,7 +289,7 @@ impl Txn {
         assert!(!self.c_else, "cannot call and_then after or_else");
 
         self.c_then = true;
-        self.success = operations.into().into();
+        self.success = operations.into();
         self
     }
 
@@ -300,7 +300,7 @@ impl Txn {
         assert!(!self.c_else, "cannot call or_else twice");
 
         self.c_else = true;
-        self.failure = operations.into().into();
+        self.failure = operations.into();
         self
     }
 }

--- a/madsim-etcd-client/src/server.rs
+++ b/madsim-etcd-client/src/server.rs
@@ -1,7 +1,7 @@
 use madsim::net::{Endpoint, Payload};
 use std::{io::Result, net::SocketAddr, sync::Arc};
 
-use super::{election::*, kv::*, service::EtcdService};
+use super::{election::*, kv::*, service::EtcdService, Bytes};
 
 /// A simulated etcd server.
 #[derive(Default, Clone)]
@@ -79,16 +79,16 @@ impl SimServer {
 pub(crate) enum Request {
     // kv API
     Put {
-        key: Vec<u8>,
-        value: Vec<u8>,
+        key: Bytes,
+        value: Bytes,
         options: PutOptions,
     },
     Get {
-        key: Vec<u8>,
+        key: Bytes,
         options: GetOptions,
     },
     Delete {
-        key: Vec<u8>,
+        key: Bytes,
         options: DeleteOptions,
     },
     Txn {
@@ -114,20 +114,20 @@ pub(crate) enum Request {
 
     // election API
     Campaign {
-        name: Vec<u8>,
-        value: Vec<u8>,
+        name: Bytes,
+        value: Bytes,
         lease: i64,
     },
     Proclaim {
         leader: LeaderKey,
-        value: Vec<u8>,
+        value: Bytes,
     },
     Leader {
-        name: Vec<u8>,
+        name: Bytes,
     },
     Observe {
         #[allow(dead_code)]
-        name: Vec<u8>,
+        name: Bytes,
     },
     Resign {
         leader: LeaderKey,

--- a/madsim-etcd-client/src/service.rs
+++ b/madsim-etcd-client/src/service.rs
@@ -16,10 +16,11 @@ pub struct EtcdService {
 
 impl EtcdService {
     pub fn new(timeout_rate: f32, data: Option<String>) -> Self {
-        let inner = Arc::new(Mutex::new(data.map_or_else(
-            || ServiceInner::default(),
-            |data| serde_json::from_str(&data).expect("failed to deserialize dump"),
-        )));
+        let inner = Arc::new(Mutex::new(
+            data.map_or_else(ServiceInner::default, |data| {
+                serde_json::from_str(&data).expect("failed to deserialize dump")
+            }),
+        ));
         let weak = Arc::downgrade(&inner);
         madsim::task::spawn(async move {
             while let Some(inner) = weak.upgrade() {

--- a/madsim-etcd-client/src/service.rs
+++ b/madsim-etcd-client/src/service.rs
@@ -111,7 +111,7 @@ impl EtcdService {
 
     pub async fn dump(&self) -> Result<String> {
         let inner = &*self.inner.lock();
-        Ok(serde_json::to_string(inner).expect("failed to serialize dump"))
+        Ok(serde_json::to_string_pretty(inner).expect("failed to serialize dump"))
     }
 
     async fn timeout(&self) -> Result<()> {

--- a/madsim-etcd-client/src/sim.rs
+++ b/madsim-etcd-client/src/sim.rs
@@ -1,3 +1,4 @@
+mod bytes;
 mod election;
 mod error;
 mod kv;
@@ -9,6 +10,7 @@ use madsim::net::Endpoint;
 use std::net::SocketAddr;
 use std::time::Duration;
 
+pub use self::bytes::Bytes;
 pub use self::election::*;
 pub use self::error::{Error, Result};
 pub use self::kv::*;

--- a/madsim-etcd-client/src/sim.rs
+++ b/madsim-etcd-client/src/sim.rs
@@ -6,6 +6,7 @@ mod server;
 mod service;
 
 use madsim::net::Endpoint;
+use std::net::SocketAddr;
 use std::time::Duration;
 
 pub use self::election::*;
@@ -14,12 +15,13 @@ pub use self::kv::*;
 pub use self::lease::*;
 pub use self::server::SimServer;
 
+use self::server::Request;
+
 /// Asynchronous `etcd` client using v3 API.
 #[derive(Clone)]
 pub struct Client {
-    kv: KvClient,
-    lease: LeaseClient,
-    election: ElectionClient,
+    ep: Endpoint,
+    server_addr: SocketAddr,
 }
 
 impl Client {
@@ -30,29 +32,35 @@ impl Client {
     ) -> Result<Self> {
         let addr = endpoints.as_ref()[0].as_ref();
         let ep = Endpoint::connect(addr).await?;
-        Ok(Client {
-            kv: KvClient::new(ep.clone()),
-            lease: LeaseClient::new(ep.clone()),
-            election: ElectionClient::new(ep),
-        })
+        let server_addr = ep.peer_addr().unwrap();
+        Ok(Client { ep, server_addr })
     }
 
     /// Gets a KV client.
     #[inline]
     pub fn kv_client(&self) -> KvClient {
-        self.kv.clone()
+        KvClient::new(self.ep.clone())
     }
 
     /// Gets a lease client.
     #[inline]
     pub fn lease_client(&self) -> LeaseClient {
-        self.lease.clone()
+        LeaseClient::new(self.ep.clone())
     }
 
     /// Gets a election client.
     #[inline]
     pub fn election_client(&self) -> ElectionClient {
-        self.election.clone()
+        ElectionClient::new(self.ep.clone())
+    }
+
+    /// Dump the data of the etcd server.
+    #[inline]
+    pub async fn dump(&mut self) -> Result<String> {
+        let req = Request::Dump;
+        let (tx, mut rx) = self.ep.connect1(self.server_addr).await?;
+        tx.send(Box::new(req)).await?;
+        *rx.recv().await?.downcast::<Result<String>>().unwrap()
     }
 }
 

--- a/madsim-etcd-client/tests/test.rs
+++ b/madsim-etcd-client/tests/test.rs
@@ -1,4 +1,4 @@
-// #![cfg(madsim)]
+#![cfg(madsim)]
 
 use madsim::{runtime::Handle, time::sleep};
 use madsim_etcd_client::{Client, SimServer};
@@ -53,11 +53,16 @@ async fn load_dump() {
     let dump = client
         .spawn(async move {
             let mut client = Client::connect(["10.0.0.1:2379"], None).await.unwrap();
-            client.kv_client().put("foo", "bar", None).await.unwrap();
+            client
+                .kv_client()
+                .put("foo", &b"bar\xFF\x01\x02"[..], None)
+                .await
+                .unwrap();
             client.dump().await.unwrap()
         })
         .await
         .unwrap();
+    tracing::info!(%dump);
 
     server.spawn(async move {
         SimServer::builder()
@@ -72,7 +77,7 @@ async fn load_dump() {
         .spawn(async move {
             let client = Client::connect(["10.0.0.1:2380"], None).await.unwrap();
             let resp = client.kv_client().get("foo", None).await.unwrap();
-            assert_eq!(resp.kvs()[0].value(), b"bar");
+            assert_eq!(resp.kvs()[0].value(), b"bar\xFF\x01\x02");
         })
         .await
         .unwrap();

--- a/madsim-etcd-client/tests/test.rs
+++ b/madsim-etcd-client/tests/test.rs
@@ -1,0 +1,35 @@
+// #![cfg(madsim)]
+
+use madsim::{runtime::Handle, time::sleep};
+use madsim_etcd_client::{Client, SimServer};
+use std::time::Duration;
+
+#[madsim::test]
+async fn kv() {
+    let handle = Handle::current();
+    let ip1 = "10.0.0.1".parse().unwrap();
+    let ip2 = "10.0.0.2".parse().unwrap();
+    let server = handle.create_node().name("server").ip(ip1).build();
+    let client = handle.create_node().name("client").ip(ip2).build();
+
+    server.spawn(async move {
+        SimServer::builder()
+            .serve("10.0.0.1:2379".parse().unwrap())
+            .await
+            .unwrap();
+    });
+    sleep(Duration::from_secs(1)).await;
+
+    let task1 = client.spawn(async move {
+        let client = Client::connect(["10.0.0.1:2379"], None).await.unwrap();
+        let mut client = client.kv_client();
+        // put kv
+        client.put("foo", "bar", None).await.unwrap();
+        // get kv
+        let resp = client.get("foo", None).await.unwrap();
+        let kv = &resp.kvs()[0];
+        assert_eq!(kv.key(), b"foo");
+        assert_eq!(kv.value(), b"bar");
+    });
+    task1.await.unwrap();
+}


### PR DESCRIPTION
This PR introduces `Client::dump()` and `SimServer::load()` function to dump and load etcd data.
The data would be dumped in pretty json format, in which bytes are encoded in [Rust ascii escape format](https://doc.rust-lang.org/std/ascii/fn.escape_default.html#) to make it human-readable.

Example dump data:

```json
{
  "revision": 516,
  "kv": {
    "cf/meta/leader": "\\n\\x0c0.0.0.0:5690",
  },
  "lease": {}
}
```