### PR TITLE
fix(time): fix time interception on ARM64 macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12] - 2022-12-13
+
+### Fixed
+
+- madsim: Fix `Instant` interception on ARM64 macOS caused by change in Rust nightly.
+
 ## [0.2.11] - 2022-12-02
 
 ### Added

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Deterministic Simulator for distributed systems."
@@ -38,6 +38,7 @@ async-channel = "1.6"
 downcast-rs = "1.2"
 libc = "0.2"
 naive-timer = "0.2"
+rustversion = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 toml = "0.5"
 


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

https://github.com/rust-lang/rust/pull/103594 changed the internal structure of `Instant` on ARM64 macOS.