### PR TITLE
fix(etcd): fix various bugs in election API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- etcd: Add `KeyValue::lease` and maintenance `status` API.
+- etcd: Add `KeyValue::{lease, create_revision, mod_revision}` API.
+- etcd: Add maintenance `status` API.
+
+### Fixed
+
+- etcd: Fix response stream of `keep_alive`.
 
 ## [0.2.13] - 2023-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - etcd: Fix response stream of `keep_alive`.
+- etcd: Fix waking up other candidates on leadership resign or lease revoke.
+- etcd: Fix unimplemented election `observe`.
 
 ## [0.2.13] - 2023-01-09
 

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -26,3 +26,6 @@ thiserror = "1"
 toml = "0.5"
 tonic = { version = "0.8", default-features = false }
 tracing = "0.1"
+
+[dev-dependencies]
+tracing-subscriber = "0.3"

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -25,6 +25,7 @@ spin = "0.9"
 thiserror = "1"
 toml = "0.5"
 tonic = { version = "0.8", default-features = false }
+tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/madsim-etcd-client/src/kv.rs
+++ b/madsim-etcd-client/src/kv.rs
@@ -1,5 +1,6 @@
 use super::{server::Request, Bytes, ResponseHeader, Result};
 use madsim::net::Endpoint;
+use serde::{Deserialize, Serialize};
 use std::{fmt::Display, net::SocketAddr};
 
 /// Client for KV operations.
@@ -484,7 +485,7 @@ impl TxnResponse {
 }
 
 /// Key-value pair.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct KeyValue {
     pub(crate) key: Bytes,
     pub(crate) value: Bytes,

--- a/madsim-etcd-client/src/server.rs
+++ b/madsim-etcd-client/src/server.rs
@@ -81,7 +81,7 @@ impl SimServer {
                                     let response: super::Result<LeaderResponse> =
                                         Ok(LeaderResponse {
                                             header: service.header(),
-                                            kv: Some(event.kv.into()),
+                                            kv: Some(event.kv),
                                         });
                                     if tx.send(Box::new(response) as Payload).await.is_err() {
                                         return Ok(());

--- a/madsim-etcd-client/src/server.rs
+++ b/madsim-etcd-client/src/server.rs
@@ -37,38 +37,44 @@ impl SimServer {
             let (tx, mut rx, _) = ep.accept1().await?;
             let service = service.clone();
             madsim::task::spawn(async move {
-                let request = *rx.recv().await?.downcast::<Request>().unwrap();
-                let response: Payload = match request {
-                    Request::Put {
-                        key,
-                        value,
-                        options,
-                    } => Box::new(service.put(key, value, options).await),
-                    Request::Get { key, options } => Box::new(service.get(key, options).await),
-                    Request::Delete { key, options } => {
-                        Box::new(service.delete(key, options).await)
-                    }
-                    Request::Txn { txn } => Box::new(service.txn(txn).await),
-                    Request::LeaseGrant { ttl, id } => Box::new(service.lease_grant(ttl, id).await),
-                    Request::LeaseRevoke { id } => Box::new(service.lease_revoke(id).await),
-                    Request::LeaseKeepAlive { id } => Box::new(service.lease_keep_alive(id).await),
-                    Request::LeaseTimeToLive { id, keys } => {
-                        Box::new(service.lease_time_to_live(id, keys).await)
-                    }
-                    Request::LeaseLeases => Box::new(service.lease_leases().await),
-                    Request::Campaign { name, value, lease } => {
-                        Box::new(service.campaign(name, value, lease).await)
-                    }
-                    Request::Proclaim { leader, value } => {
-                        Box::new(service.proclaim(leader, value).await)
-                    }
-                    Request::Leader { name } => Box::new(service.leader(name).await),
-                    Request::Observe { name: _ } => todo!(),
-                    Request::Resign { leader } => Box::new(service.resign(leader).await),
-                    Request::Status => Box::new(service.status().await),
-                    Request::Dump => Box::new(service.dump().await),
-                };
-                tx.send(response).await?;
+                while let Ok(request) = rx.recv().await {
+                    let request = *request.downcast::<Request>().unwrap();
+                    let response: Payload = match request {
+                        Request::Put {
+                            key,
+                            value,
+                            options,
+                        } => Box::new(service.put(key, value, options).await),
+                        Request::Get { key, options } => Box::new(service.get(key, options).await),
+                        Request::Delete { key, options } => {
+                            Box::new(service.delete(key, options).await)
+                        }
+                        Request::Txn { txn } => Box::new(service.txn(txn).await),
+                        Request::LeaseGrant { ttl, id } => {
+                            Box::new(service.lease_grant(ttl, id).await)
+                        }
+                        Request::LeaseRevoke { id } => Box::new(service.lease_revoke(id).await),
+                        Request::LeaseKeepAlive { id } => {
+                            Box::new(service.lease_keep_alive(id).await)
+                        }
+                        Request::LeaseTimeToLive { id, keys } => {
+                            Box::new(service.lease_time_to_live(id, keys).await)
+                        }
+                        Request::LeaseLeases => Box::new(service.lease_leases().await),
+                        Request::Campaign { name, value, lease } => {
+                            Box::new(service.campaign(name, value, lease).await)
+                        }
+                        Request::Proclaim { leader, value } => {
+                            Box::new(service.proclaim(leader, value).await)
+                        }
+                        Request::Leader { name } => Box::new(service.leader(name).await),
+                        Request::Observe { name: _ } => todo!(),
+                        Request::Resign { leader } => Box::new(service.resign(leader).await),
+                        Request::Status => Box::new(service.status().await),
+                        Request::Dump => Box::new(service.dump().await),
+                    };
+                    tx.send(response).await?;
+                }
                 Ok(()) as Result<()>
             });
         }

--- a/madsim-etcd-client/src/service.rs
+++ b/madsim-etcd-client/src/service.rs
@@ -294,11 +294,7 @@ impl ServiceInner {
 
         PutResponse {
             header: self.header(),
-            prev_kv: if options.prev_kv {
-                prev_value.map(|info| info.into())
-            } else {
-                None
-            },
+            prev_kv: if options.prev_kv { prev_value } else { None },
         }
     }
 
@@ -308,15 +304,9 @@ impl ServiceInner {
             todo!("get with revision");
         }
         let kvs = if options.prefix {
-            self.get_prefix_range(key)
-                .map(|(_, v)| v.clone().into())
-                .collect()
+            self.get_prefix_range(key).map(|(_, v)| v.clone()).collect()
         } else {
-            self.kv
-                .get(&key)
-                .map(|v| v.clone().into())
-                .into_iter()
-                .collect()
+            self.kv.get(&key).cloned().into_iter().collect()
         };
         GetResponse {
             header: self.header(),
@@ -536,10 +526,7 @@ impl ServiceInner {
     fn leader(&self, name: Key) -> Result<LeaderResponse> {
         Ok(LeaderResponse {
             header: self.header(),
-            kv: self
-                .get_prefix_range(name)
-                .next()
-                .map(|(_, v)| v.clone().into()),
+            kv: self.get_prefix_range(name).next().map(|(_, v)| v.clone()),
         })
     }
 

--- a/madsim-etcd-client/src/sim.rs
+++ b/madsim-etcd-client/src/sim.rs
@@ -6,6 +6,7 @@ mod lease;
 mod maintenance;
 mod server;
 mod service;
+mod watch;
 
 use madsim::net::Endpoint;
 use std::net::SocketAddr;
@@ -18,6 +19,7 @@ pub use self::kv::*;
 pub use self::lease::*;
 pub use self::maintenance::*;
 pub use self::server::SimServer;
+pub use self::watch::*;
 
 use self::server::Request;
 

--- a/madsim-etcd-client/src/watch.rs
+++ b/madsim-etcd-client/src/watch.rs
@@ -1,0 +1,8 @@
+/// The kind of event.
+#[repr(i32)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EventType {
+    #[default]
+    Put = 0,
+    Delete = 1,
+}

--- a/madsim-etcd-client/tests/test.rs
+++ b/madsim-etcd-client/tests/test.rs
@@ -1,7 +1,7 @@
 #![cfg(madsim)]
 
 use madsim::{runtime::Handle, time::sleep};
-use madsim_etcd_client::{Client, PutOptions, SimServer};
+use madsim_etcd_client::{Client, ProclaimOptions, PutOptions, ResignOptions, SimServer};
 use std::time::Duration;
 
 #[madsim::test]
@@ -103,6 +103,94 @@ async fn lease() {
         assert!(resp.kvs().is_empty());
     });
     task1.await.unwrap();
+}
+
+#[madsim::test]
+async fn election() {
+    tracing_subscriber::fmt::init();
+
+    let handle = Handle::current();
+    let ip1 = "10.0.0.1".parse().unwrap();
+    let ip2 = "10.0.0.2".parse().unwrap();
+    let ip3 = "10.0.0.3".parse().unwrap();
+    let ip4 = "10.0.0.4".parse().unwrap();
+    let server = handle.create_node().name("server").ip(ip1).build();
+    let client1 = handle.create_node().name("client1").ip(ip2).build();
+    let client2 = handle.create_node().name("client2").ip(ip3).build();
+    let client3 = handle.create_node().name("client3").ip(ip4).build();
+
+    server.spawn(async move {
+        SimServer::builder()
+            .serve("10.0.0.1:2379".parse().unwrap())
+            .await
+            .unwrap();
+    });
+    sleep(Duration::from_secs(1)).await;
+
+    // first leader
+    let task1 = client1.spawn(async move {
+        let client = Client::connect(["10.0.0.1:2379"], None).await.unwrap();
+        let mut lease_client = client.lease_client();
+        let mut client = client.election_client();
+        // grant lease
+        let lease = lease_client.grant(60, None).await.unwrap();
+        // campaign to be leader
+        let resp = client.campaign("leader", "1", lease.id()).await.unwrap();
+        let leader_key = resp.leader().unwrap();
+        assert_eq!(leader_key.name(), b"leader");
+        assert_eq!(leader_key.lease(), lease.id());
+        // get leader
+        let resp = client.leader("leader").await.unwrap();
+        assert_eq!(resp.kv().unwrap().value(), b"1");
+        // proclaim
+        let opt = ProclaimOptions::new().with_leader(leader_key.clone());
+        client.proclaim("1.1", Some(opt.clone())).await.unwrap();
+        let resp = client.leader("leader").await.unwrap();
+        assert_eq!(resp.kv().unwrap().value(), b"1.1");
+        // wait for 30s
+        sleep(Duration::from_secs(30)).await;
+        // revoke lease to release leadership
+        lease_client.revoke(lease.id()).await.unwrap();
+        // proclaim should fail
+        client.proclaim("1.2", Some(opt.clone())).await.unwrap_err();
+    });
+
+    // second leader
+    let task2 = client2.spawn(async move {
+        let client = Client::connect(["10.0.0.1:2379"], None).await.unwrap();
+        let mut lease_client = client.lease_client();
+        let mut client = client.election_client();
+        // sleep for a while to make sure client1 become leader
+        sleep(Duration::from_secs(10)).await;
+        // grant lease
+        let lease = lease_client.grant(60, None).await.unwrap();
+        // to be leader
+        let resp = client.campaign("leader", "2", lease.id()).await.unwrap();
+        let leader_key = resp.leader().unwrap();
+        assert_eq!(leader_key.name(), b"leader");
+        assert_eq!(leader_key.lease(), lease.id());
+        // resign
+        let opt = ResignOptions::new().with_leader(leader_key.clone());
+        client.resign(Some(opt)).await.unwrap();
+    });
+
+    // observer
+    let task3 = client3.spawn(async move {
+        let client = Client::connect(["10.0.0.1:2379"], None).await.unwrap();
+        let mut client = client.election_client();
+        // todo
+        // let mut leader_stream = client.observe("leader").await.unwrap();
+        // let resp = leader_stream.message().await.unwrap().unwrap();
+        // assert_eq!(resp.kv().unwrap().value(), b"1");
+        // let resp = leader_stream.message().await.unwrap().unwrap();
+        // assert_eq!(resp.kv().unwrap().value(), b"1.1");
+        // let resp = leader_stream.message().await.unwrap().unwrap();
+        // assert_eq!(resp.kv().unwrap().value(), b"2");
+    });
+
+    task1.await.unwrap();
+    task2.await.unwrap();
+    task3.await.unwrap();
 }
 
 #[madsim::test]

--- a/madsim-etcd-client/tests/test.rs
+++ b/madsim-etcd-client/tests/test.rs
@@ -107,7 +107,7 @@ async fn lease() {
 
 #[madsim::test]
 async fn election() {
-    tracing_subscriber::fmt::init();
+    // tracing_subscriber::fmt::init();
 
     let handle = Handle::current();
     let ip1 = "10.0.0.1".parse().unwrap();
@@ -178,14 +178,14 @@ async fn election() {
     let task3 = client3.spawn(async move {
         let client = Client::connect(["10.0.0.1:2379"], None).await.unwrap();
         let mut client = client.election_client();
-        // todo
-        // let mut leader_stream = client.observe("leader").await.unwrap();
-        // let resp = leader_stream.message().await.unwrap().unwrap();
-        // assert_eq!(resp.kv().unwrap().value(), b"1");
-        // let resp = leader_stream.message().await.unwrap().unwrap();
-        // assert_eq!(resp.kv().unwrap().value(), b"1.1");
-        // let resp = leader_stream.message().await.unwrap().unwrap();
-        // assert_eq!(resp.kv().unwrap().value(), b"2");
+
+        let mut leader_stream = client.observe("leader").await.unwrap();
+        let resp = leader_stream.message().await.unwrap().unwrap();
+        assert_eq!(resp.kv().unwrap().value(), b"1");
+        let resp = leader_stream.message().await.unwrap().unwrap();
+        assert_eq!(resp.kv().unwrap().value(), b"1.1");
+        let resp = leader_stream.message().await.unwrap().unwrap();
+        assert_eq!(resp.kv().unwrap().value(), b"2");
     });
 
     task1.await.unwrap();

--- a/madsim-etcd-client/tests/test.rs
+++ b/madsim-etcd-client/tests/test.rs
@@ -85,9 +85,13 @@ async fn lease() {
 
         // keep alive for 90s
         sleep(Duration::from_secs(45)).await;
-        let (mut keeper, _) = lease_client.keep_alive(lease.id()).await.unwrap();
+        let (mut keeper, mut responses) = lease_client.keep_alive(lease.id()).await.unwrap();
         sleep(Duration::from_secs(45)).await;
         keeper.keep_alive().await.unwrap();
+        let resp = responses.message().await.unwrap().unwrap();
+        assert_eq!(resp.id(), lease.id());
+        assert!(resp.ttl() <= 60 && resp.ttl() > 50);
+
         // get kv
         let resp = kv_client.get("foo", None).await.unwrap();
         assert_eq!(resp.kvs().len(), 1);


### PR DESCRIPTION
- fix response stream of lease `keep_alive`.
- fix waking up other candidates on leadership resign or lease revoke.
- fix unimplemented election `observe`.
- add tests for election API