### PR TITLE
fix(task): kill other tasks after the initial task completes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - madsim: Add `buggify`.
 - madsim: Add `JoinHandle::{id, is_finished}`.
 - madsim: Add `signal::ctrl_c` and `Handle::send_ctrl_c`.
+- madsim: Add `Handle::is_exit`.
+
+### Changed
+
+- madsim: After the initial task completes, the other tasks of the node are dropped.
 
 ### Fixed
 

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -266,6 +266,11 @@ impl Handle {
         self.task.send_ctrl_c(id);
     }
 
+    /// Returns whether the node is killed or exited.
+    pub fn is_exit(&self, id: impl ToNodeId) -> bool {
+        self.task.is_exit(id)
+    }
+
     /// Create a node which will be bound to the specified address.
     pub fn create_node(&self) -> NodeBuilder<'_> {
         NodeBuilder::new(self)
@@ -310,12 +315,17 @@ impl<'a> NodeBuilder<'a> {
     /// Set the initial task for the node.
     ///
     /// This task will be respawned when calling `restart`.
-    pub fn init<F>(mut self, future: impl Fn() -> F + Send + Sync + 'static) -> Self
+    pub fn init<F>(mut self, new_task: impl Fn() -> F + Send + Sync + 'static) -> Self
     where
         F: Future + 'static,
     {
         self.init = Some(Arc::new(move |handle| {
-            handle.spawn_local(future());
+            let future = new_task();
+            let h = handle.clone();
+            handle.spawn_local(async move {
+                future.await;
+                h.exit();
+            });
         }));
         self
     }


### PR DESCRIPTION
To simulate the behavior of process exit.
Also add `Handle::is_exit` API.