### PR TITLE
fix: break cascade drop to prevent deadlock on kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- etcd: Support "etcdserver: request is too large".
+
 ### Fixed
 
-- etcd: support "etcdserver: request is too large".
+- madsim: Prevent deadlock when killing a node.
 
 ## [0.2.16] - 2023-02-14
 


### PR DESCRIPTION
When killing a node, it may cause a cascade drop for the tasks of this node, where there will be a reentrancy of a lock in the call stack. This way, the program will fall into a deadlock.
This PR fixes it by introducing a temporary store for `runnable` when being wakened up on kill so that the cascade drop can be broken.