### PR TITLE
feat(rdkafka): cherry-pick DNS resolve callback from Materialize

### DIFF
--- a/madsim-rdkafka/Cargo.toml
+++ b/madsim-rdkafka/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0"
 async-channel = "1"
 async-trait = "0.1"
 futures-util = "0.3"
-madsim = { version = "0.2.8", path = "../madsim" }
+madsim = { version = "0.2.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 spin = "0.9"

--- a/madsim-rdkafka/Cargo.toml
+++ b/madsim-rdkafka/Cargo.toml
@@ -26,7 +26,8 @@ tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
 async-trait = "0.1"
-rdkafka-sys = { version = "4.3.0", default-features = false }
+# rdkafka-sys = { version = "4.3.0", default-features = false }
+rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka", rev = "8ea07c4", default-features = false }
 futures-channel = "0.3.0"
 futures-executor = { version = "0.3.0", optional = true }
 futures-util = { version = "0.3.0", default-features = false }

--- a/madsim-rdkafka/src/std/client.rs
+++ b/madsim-rdkafka/src/std/client.rs
@@ -21,6 +21,7 @@ use std::slice;
 use std::string::ToString;
 use std::sync::Arc;
 
+use libc::addrinfo;
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
@@ -113,6 +114,19 @@ pub trait ClientContext: Send + Sync + 'static {
     /// The default implementation logs the error at the `error` log level.
     fn error(&self, error: KafkaError, reason: &str) {
         error!("librdkafka: {}: {}", error, reason);
+    }
+
+    /// Rewrites a broker address for DNS resolution.
+    ///
+    /// This method is invoked before performing DNS resolution on a broker
+    /// address. The returned address is used in place of the original address.
+    /// It is useful to allow connecting to a Kafka cluster over a tunnel (e.g.,
+    /// SSH or AWS PrivateLink), where the broker addresses returned by the
+    /// bootstrap server need to be rewritten to be routed through the tunnel.
+    ///
+    /// The default implementation returns the address unchanged.
+    fn rewrite_broker_addr(&self, addr: BrokerAddr) -> BrokerAddr {
+        addr
     }
 
     /// Generates an OAuth token from the provided configuration.
@@ -229,13 +243,12 @@ impl<C: ClientContext> Client<C> {
                 Arc::as_ptr(&context) as *mut c_void,
             )
         };
-        unsafe { rdsys::rd_kafka_conf_set_log_cb(native_config.ptr(), Some(native_log_cb::<C>)) };
         unsafe {
-            rdsys::rd_kafka_conf_set_stats_cb(native_config.ptr(), Some(native_stats_cb::<C>))
-        };
-        unsafe {
-            rdsys::rd_kafka_conf_set_error_cb(native_config.ptr(), Some(native_error_cb::<C>))
-        };
+            rdsys::rd_kafka_conf_set_log_cb(native_config.ptr(), Some(native_log_cb::<C>));
+            rdsys::rd_kafka_conf_set_stats_cb(native_config.ptr(), Some(native_stats_cb::<C>));
+            rdsys::rd_kafka_conf_set_error_cb(native_config.ptr(), Some(native_error_cb::<C>));
+            rdsys::rd_kafka_conf_set_resolve_cb(native_config.ptr(), Some(native_resolve_cb::<C>));
+        }
         if C::ENABLE_REFRESH_OAUTH_TOKEN {
             unsafe {
                 rdsys::rd_kafka_conf_set_oauthbearer_token_refresh_cb(
@@ -492,6 +505,51 @@ pub(crate) unsafe extern "C" fn native_error_cb<C: ClientContext>(
 
     let context = &mut *(opaque as *mut C);
     context.error(error, reason.trim());
+}
+
+pub(crate) unsafe extern "C" fn native_resolve_cb<C: ClientContext>(
+    node: *const c_char,
+    service: *const c_char,
+    hints: *const addrinfo,
+    res: *mut *mut addrinfo,
+    opaque: *mut c_void,
+) -> i32 {
+    // Convert host and port to Rust strings.
+    let host = match CStr::from_ptr(node).to_str() {
+        Ok(host) => host.into(),
+        Err(_) => return libc::EAI_FAIL,
+    };
+    let port = match CStr::from_ptr(service).to_str() {
+        Ok(port) => port.into(),
+        Err(_) => return libc::EAI_FAIL,
+    };
+
+    // Apply the rewrite in the context.
+    let context = &mut *(opaque as *mut C);
+    let addr = context.rewrite_broker_addr(BrokerAddr { host, port });
+
+    // Convert host and port back to C strings.
+    let node = match CString::new(addr.host) {
+        Ok(node) => node,
+        Err(_) => return libc::EAI_FAIL,
+    };
+    let service = match CString::new(addr.port) {
+        Ok(service) => service,
+        Err(_) => return libc::EAI_FAIL,
+    };
+
+    // Perform DNS resolution.
+    unsafe { libc::getaddrinfo(node.as_ptr(), service.as_ptr(), hints, res) }
+}
+
+/// Describes the address of a broker in a Kafka cluster.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct BrokerAddr {
+    /// The host name.
+    pub host: String,
+    /// The port, either as a decimal number or the name of a service in
+    /// the services database.
+    pub port: String,
 }
 
 /// A generated OAuth token and its associated metadata.

--- a/madsim-rdkafka/src/std/producer/future_producer.rs
+++ b/madsim-rdkafka/src/std/producer/future_producer.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use futures_channel::oneshot;
 use futures_util::FutureExt;
 
-use crate::client::{Client, ClientContext, DefaultClientContext, OAuthToken};
+use crate::client::{BrokerAddr, Client, ClientContext, DefaultClientContext, OAuthToken};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel};
 use crate::consumer::ConsumerGroupMetadata;
 use crate::error::{KafkaError, KafkaResult, RDKafkaErrorCode};
@@ -154,6 +154,10 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
 
     fn error(&self, error: KafkaError, reason: &str) {
         self.wrapped_context.error(error, reason);
+    }
+
+    fn rewrite_broker_addr(&self, addr: BrokerAddr) -> BrokerAddr {
+        self.wrapped_context.rewrite_broker_addr(addr)
     }
 
     fn generate_oauth_token(


### PR DESCRIPTION
Cherry-pick https://github.com/MaterializeInc/rust-rdkafka/commit/8ea07c4d2b96636ff093e670bc921892aee0d56a.
Note that we will no longer publish madsim-rdkafka to crates.io since this PR, because it depends on materialize's fork of rdkafka-sys. But since their patch has been merged into the upstream, we can wait for a new release and then switch it back.