### PR TITLE
fix: replace RNG for reproducibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- madsim: Replace `SmallRng` with `Xoshiro256PlusPlus` for reproducibility across platforms.
+
 ## [0.2.17] - 2023-02-17
 
 ### Fixed

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1"
 futures-util = "0.3"
 lazy_static = "1.4"
 madsim-macros = { version = "0.2", path = "../madsim-macros", optional = true }
-rand = { version = "0.8", features = ["small_rng"] }
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 spin = "0.9"
 tracing = "0.1"
@@ -38,6 +38,7 @@ async-channel = "1.6"
 downcast-rs = "1.2"
 libc = "0.2"
 naive-timer = "0.2"
+rand_xoshiro = "0.6"
 rustversion = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 toml = "0.7"

--- a/madsim/src/sim/rand.rs
+++ b/madsim/src/sim/rand.rs
@@ -2,10 +2,8 @@
 //!
 //! This module re-exports the [`rand`] crate, except for the random number generators.
 
-use rand::{
-    distributions::Standard,
-    prelude::{Distribution, SmallRng},
-};
+use rand::{distributions::Standard, prelude::Distribution};
+use rand_xoshiro::Xoshiro256PlusPlus;
 
 use spin::Mutex;
 use std::cell::Cell;
@@ -33,7 +31,7 @@ pub struct GlobalRng {
 
 struct Inner {
     seed: u64,
-    rng: SmallRng,
+    rng: Xoshiro256PlusPlus,
     log: Option<Vec<u8>>,
     check: Option<(Vec<u8>, usize)>,
     buggify: bool,
@@ -63,7 +61,7 @@ impl GlobalRng {
     }
 
     /// Call function on the inner RNG.
-    pub(crate) fn with<T>(&self, f: impl FnOnce(&mut SmallRng) -> T) -> T {
+    pub(crate) fn with<T>(&self, f: impl FnOnce(&mut Xoshiro256PlusPlus) -> T) -> T {
         let mut lock = self.inner.lock();
         let ret = f(&mut lock.rng);
         // log or check


### PR DESCRIPTION
According to the [rand docs](https://docs.rs/rand/latest/rand/rngs/struct.SmallRng.html), `SmallRng` is not considered reproducible across platforms. So replace it with a named PRNG.