### PR TITLE
fix(etcd): fix election implementation

### DIFF
--- a/madsim-etcd-client/src/kv.rs
+++ b/madsim-etcd-client/src/kv.rs
@@ -507,7 +507,7 @@ impl TxnResponse {
 }
 
 /// Key-value pair.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KeyValue {
     pub(crate) key: Bytes,
     pub(crate) value: Bytes,


### PR DESCRIPTION
This PR fixes the implementation of etcd election API. Currently, there is only one key for each election. But actually each candidate will create a key and the leader is the one with the smallest revision.

Please note that this implementation is still not exactly as the official etcd, where election API is implemented on top of KV and lease API on the client side.