### PR TITLE
feat: print context info on panic

### DIFF
--- a/madsim/src/sim/net/network.rs
+++ b/madsim/src/sim/net/network.rs
@@ -94,7 +94,7 @@ const fn default_send_latency() -> Range<Duration> {
     Duration::from_millis(1)..Duration::from_millis(10)
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Config {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.packet_loss_rate.to_bits().hash(state);

--- a/madsim/src/sim/net/tcp/config.rs
+++ b/madsim/src/sim/net/tcp/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Default)]
 pub struct TcpConfig {}
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for TcpConfig {
     fn hash<H: Hasher>(&self, _state: &mut H) {}
 }

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -384,6 +384,7 @@ impl NodeHandle {
     }
 
     /// Spawn a future onto the runtime.
+    #[track_caller]
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,


### PR DESCRIPTION
example:
```
---- basic stdout ----
thread '<unnamed>' panicked at 'explicit panic', tonic-example/tests/test.rs:43:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
context: node=1 "server", task=33 (spawned at tonic-example/tests/test.rs:42:11)
```