### PR TITLE
feat: expose `TaskLocalFuture`

### DIFF
--- a/madsim-tokio/src/lib.rs
+++ b/madsim-tokio/src/lib.rs
@@ -29,6 +29,10 @@ mod sim {
         pub use madsim::task::*;
         #[cfg(feature = "rt")]
         pub use tokio::task::LocalKey;
+        #[cfg(feature = "rt")]
+        pub mod futures {
+            pub use tokio::task::futures::TaskLocalFuture;
+        }
     }
 
     // not simulated API


### PR DESCRIPTION
This PR exposes `TaskLocalFuture` from `tokio`, which is also part of the `task_local` API.