### PR TITLE
chore: bump aws sdk to the latest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "rust-analyzer.cargo.features": [
+
+    ],
+    "rust-analyzer.cargo.extraEnv": {
+        "RUSTFLAGS": "--cfg tokio_unstable --cfg madsim"
+    }
+}

--- a/madsim-aws-sdk-s3/Cargo.toml
+++ b/madsim-aws-sdk-s3/Cargo.toml
@@ -14,14 +14,14 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-s3 = "0.35"
+aws-sdk-s3 = "0.39"
 
 [target.'cfg(madsim)'.dependencies]
 madsim = "0.2.15"
-aws-smithy-http = "0.57"
-aws-smithy-runtime-api = "0.57"
-aws-smithy-types = "0.57"
-aws-types = "0.57"
+aws-smithy-http = "0.60"
+aws-smithy-runtime-api = "1.0"
+aws-smithy-types = "1.0"
+aws-types = "1.0"
 bytes = "1"
 http = "0.2"
 spin = "0.9"

--- a/madsim-aws-sdk-s3/src/client.rs
+++ b/madsim-aws-sdk-s3/src/client.rs
@@ -39,7 +39,10 @@ impl Client {
         resp.map_err(|e| {
             SdkError::service_error(
                 e,
-                http::response::Response::new(aws_smithy_types::body::SdkBody::empty()),
+                aws_smithy_runtime_api::http::Response::new(
+                    aws_smithy_runtime_api::http::StatusCode::try_from(500).unwrap(),
+                    aws_smithy_types::body::SdkBody::empty(),
+                ),
             )
         })
     }

--- a/madsim-aws-sdk-s3/src/server/service.rs
+++ b/madsim-aws-sdk-s3/src/server/service.rs
@@ -325,7 +325,7 @@ impl ServiceInner {
             multipart.sort_by_key(|part| part.part_number);
             for completed_part in multipart {
                 for part in parts.iter() {
-                    if part.part_number == completed_part.part_number {
+                    if part.part_number == completed_part.part_number.unwrap_or_default() {
                         if let Some(e_tag) = &completed_part.e_tag {
                             if e_tag == &part.e_tag {
                                 body.extend(&part.body);


### PR DESCRIPTION
```
aws-sdk-s3: 0.35 => 0.39
aws-smithy-http: 0.57 => 0.60
aws-smithy-runtime-api: 0.57 => 1.0
aws-smithy-types: 0.57 => 1.0
aws-types: 0.57 => 1.0
```