### PR TITLE
chore: bump madsim-aws-sdk-s3 to v0.5.0+1 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tokio = { version = "0.2", package = "madsim-tokio" }
 tonic = { version = "0.4", package = "madsim-tonic" }
 etcd-client = { version = "0.4", package = "madsim-etcd-client" }
 rdkafka = { version = "0.3", package = "madsim-rdkafka" }
-aws-sdk-s3 = { version = "0.4", package = "madsim-aws-sdk-s3" }
+aws-sdk-s3 = { version = "0.5", package = "madsim-aws-sdk-s3" }
 
 [dev-dependencies]
 tonic-build = { version = "0.4", package = "madsim-tonic-build" }

--- a/madsim-aws-sdk-s3/Cargo.toml
+++ b/madsim-aws-sdk-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-aws-sdk-s3"
-version = "0.4.0+0.39"
+version = "0.5.0+1"
 edition = "2021"
 authors = ["Kevin Axel <kevinaxel@163.com>"]
 description = "The s3 simulator on madsim."

--- a/madsim-aws-sdk-s3/README.md
+++ b/madsim-aws-sdk-s3/README.md
@@ -1,6 +1,6 @@
 # madsim-s3-client
 
-The `aws-sdk-s3` simulator on madsim. Mirrors [aws-sdk-s3 v0.39.0](https://docs.rs/aws-sdk-s3/0.39.0/aws_sdk_s3/index.html).
+The `aws-sdk-s3` simulator on madsim. Mirrors [aws-sdk-s3 v1.2.0](https://docs.rs/aws-sdk-s3/1.2.0/aws_sdk_s3/index.html).
 
 > If it looks like s3, acts like s3, and is used like s3, then it probably is s3.
 
@@ -10,5 +10,5 @@ Replace all `aws-sdk-s3` entries in your Cargo.toml:
 
 ```toml
 [dependencies]
-aws-sdk-s3 = { version = "0.4", package = "madsim-aws-sdk-s3" }
+aws-sdk-s3 = { version = "0.5", package = "madsim-aws-sdk-s3" }
 ```


### PR DESCRIPTION
Bump with #186 .