### PR TITLE
fix: fix time on x86_64 macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## madsim [0.2.24] - 2024-01-05
+
+### Fixed
+
+- Fix intercepting time on x86_64 macOS, Rust 1.75.0.
+
 ## rdkafka [0.3.1] - 2024-01-05
 
 ### Fixed

--- a/madsim-aws-sdk-s3/Cargo.toml
+++ b/madsim-aws-sdk-s3/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 aws-sdk-s3 = "1"
 
 [target.'cfg(madsim)'.dependencies]
-madsim = "0.2.15"
+madsim = { version = "0.2.15", path = "../madsim" }
 aws-smithy-http = "0.60"
 aws-smithy-runtime-api = "1"
 aws-smithy-types = "1"

--- a/madsim-rdkafka/Cargo.toml
+++ b/madsim-rdkafka/Cargo.toml
@@ -17,7 +17,7 @@ async-channel = "1"
 async-trait = "0.1"
 futures-channel = "0.3.0"
 futures-util = "0.3"
-madsim = { version = "0.2.8" }
+madsim = { version = "0.2.8", path = "../madsim" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 spin = "0.9"

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -32,8 +32,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 
 [target.'cfg(madsim)'.dependencies]
-ahash = "0.7"
-async-channel = "1.6"
+ahash = "0.8"
+async-channel = "2"
 async-stream = "0.3"
 async-task = "4.4"
 downcast-rs = "1.2"
@@ -43,7 +43,7 @@ panic-message = "0.3"
 rand_xoshiro = "0.6"
 rustversion = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
-toml = "0.7"
+toml = "0.8"
 
 [target.'cfg(not(madsim))'.dependencies]
 async-ucx = { version = "0.1", features = ["event"], optional = true }
@@ -60,7 +60,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 # mad_rpc = { git = "https://github.com/madsys-dev/madrpc", rev = "2be4b02", optional = true }
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.5"
 structopt = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Deterministic Simulator for distributed systems."

--- a/madsim/src/sim/config.rs
+++ b/madsim/src/sim/config.rs
@@ -1,12 +1,8 @@
 //! Simulation configuration.
 
-use std::{
-    hash::{Hash, Hasher},
-    str::FromStr,
-};
+use std::{hash::Hash, str::FromStr};
 
 use crate::net::{self, tcp};
-use ahash::AHasher;
 use serde::{Deserialize, Serialize};
 
 /// Simulation configuration.
@@ -25,9 +21,7 @@ pub struct Config {
 impl Config {
     /// Returns the hash value of this config.
     pub fn hash(&self) -> u64 {
-        let mut hasher = AHasher::new_with_keys(0, 0);
-        Hash::hash(self, &mut hasher);
-        hasher.finish()
+        ahash::RandomState::with_seed(0).hash_one(self)
     }
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/116238 (Rust 1.75) replaced `mach_absolute_time` with `clock_gettime(CLOCK_REALTIME)` on x86_64 macOS.