### PR TITLE
fix: make `sleep` wait for at least 1ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## madsim [0.2.26] - 2024-03-18
+
+### Fixed
+
+- `sleep` and `sleep_until` now sleep for at least 1ms to be consistent with tokio's behavior.
+
 ## rdkafka [0.3.3] - 2024-02-28
 
 ### Changed

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim"
-version = "0.2.25"
+version = "0.2.26"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Deterministic Simulator for distributed systems."
@@ -62,7 +62,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 [dev-dependencies]
 criterion = "0.5"
 structopt = "0.3"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util"] }
 
 [[bench]]
 name = "rpc"


### PR DESCRIPTION
fix #198 

release madsim v0.2.26