### PR TITLE
fix(madsim): fix determinism for getrandom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## madsim [0.2.27] - 2024-04-07
+
+### Fixed
+
+- Fix the problem that `getrandom` returns different values in multiple runs with the same seed.
+
 ## rdkafka [0.3.4] - 2024-03-22
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
     "tonic-example",
 ]
 resolver = "2"
+
+[patch.crates-io]
+getrandom = { git = "https://github.com/madsim-rs/getrandom.git", rev = "6c9d9e9" }

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -63,6 +63,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 criterion = "0.5"
 structopt = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util"] }
+getrandom = "=0.2.13"
 
 [[bench]]
 name = "rpc"

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Deterministic Simulator for distributed systems."


### PR DESCRIPTION
This PR fixes #201, a bug happening on Linux only. The reason why `getrandom` yields a different value in the first run is that, a `getrandom(0, 0)` is called on first access to check the availability of this function [(code)](https://github.com/rust-random/getrandom/blob/f68a940b4dac78b49f00599aebd56c72284a92d9/src/linux_android.rs#L12). It mutates the global random state by mistake. This PR adds a branch to avoid the mutation.

release as madsim v0.2.27


