### PR TITLE
feat(rdkafka): unblock fetching functions

### DIFF
--- a/madsim-rdkafka/CHANGELOG.md
+++ b/madsim-rdkafka/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2024-05-13
+
+### Changed
+
+- Wrap `fetch_metadata`, `fetch_group_list` and `offsets_for_times` in `tokio::task::spawn_blocking`.
+
 ## [0.4.1] - 2024-05-08
 
 ### Fixed

--- a/madsim-rdkafka/Cargo.toml
+++ b/madsim-rdkafka/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-rdkafka"
-version = "0.4.1+0.34.0"
+version = "0.4.2+0.34.0"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The rdkafka simulator on madsim."

--- a/madsim-rdkafka/README.md
+++ b/madsim-rdkafka/README.md
@@ -24,9 +24,9 @@ The following functions are modified to be `async`:
 - `FromClientConfigAndContext::from_config_and_context`
 - `ClientConfig::create`
 - `ClientConfig::create_with_context`
-- `Client::fetch_metadata`
+- `Client::fetch_metadata`[^1]
 - `Client::fetch_watermarks`[^1]
-- `Client::fetch_group_list`
+- `Client::fetch_group_list`[^1]
 - `Consumer::seek`
 - `Consumer::seek_partitions`
 - `Consumer::commit`
@@ -35,10 +35,10 @@ The following functions are modified to be `async`:
 - `Consumer::committed`
 - `Consumer::committed_offsets`
 - `Consumer::offsets_for_timestamp`
-- `Consumer::offsets_for_times`
-- `Consumer::fetch_metadata`
+- `Consumer::offsets_for_times`[^1]
+- `Consumer::fetch_metadata`[^1]
 - `Consumer::fetch_watermarks`[^1]
-- `Consumer::fetch_group_list`
+- `Consumer::fetch_group_list`[^1]
 - `Producer::flush`
 - `Producer::init_transactions`
 - `Producer::send_offsets_to_transaction`

--- a/madsim-rdkafka/src/std/groups.rs
+++ b/madsim-rdkafka/src/std/groups.rs
@@ -132,6 +132,8 @@ impl fmt::Debug for GroupInfo {
 /// all the native resources when dropped.
 pub struct GroupList(NativePtr<RDKafkaGroupList>);
 
+unsafe impl Send for GroupList {}
+
 unsafe impl KafkaDrop for RDKafkaGroupList {
     const TYPE: &'static str = "group";
     const DROP: unsafe extern "C" fn(*mut Self) = drop_group_list;


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

This PR wraps the following function in `tokio::task::spawn_blocking`:
- Client::fetch_metadata
- Client::fetch_group_list
- Consumer::offsets_for_times

released as v0.4.2

cc @BugenZhao @tabVersion please let me know if there are any more functions need to wrap.