### PR TITLE
fix(tonic): allows the server to prematurely close the stream in client side streaming

### DIFF
--- a/madsim-tonic/src/client.rs
+++ b/madsim-tonic/src/client.rs
@@ -183,7 +183,7 @@ impl<F: Interceptor> Grpc<crate::transport::Channel, F> {
         // send requests
         pin_mut!(stream);
         while let Some(item) = stream.next().await {
-            /// allows the server to prematurely close the stream
+            // allows the server to prematurely close the stream
             if tx.send(Box::new(item)).await.is_err() {
                 debug!("send stream unexpectedly closed");
                 break;

--- a/madsim-tonic/src/client.rs
+++ b/madsim-tonic/src/client.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use futures_util::{pin_mut, Stream, StreamExt};
 use tonic::codegen::http::uri::PathAndQuery;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::{
     codegen::{BoxMessage, IdentityInterceptor, RequestExt},
@@ -183,7 +183,11 @@ impl<F: Interceptor> Grpc<crate::transport::Channel, F> {
         // send requests
         pin_mut!(stream);
         while let Some(item) = stream.next().await {
-            tx.send(Box::new(item)).await?;
+            /// allows the server to prematurely close the stream
+            if tx.send(Box::new(item)).await.is_err() {
+                debug!("send stream unexpectedly closed");
+                break;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
The client uses `Grpc::client_streaming` to send a stream to the server. However, in the current implementation, if the server closes the stream prematurely, the madsim channel will be closed and will return a "connection reset" error to the client. Thus, the client will never receive the response from the server. We should allow the server to close the stream before sending back the response.