### PR TITLE
fix(tonic): add missing interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## tonic [0.5.1] - 2024-08-02
+
+### Added
+
+- Add missing APIs for `tonic::transport::Server::builder`.
+- Add missing re-exports for `tonic::body`.
+
 ## tonic [0.5.0] - 2024-07-31
 
 ### Changed

--- a/madsim-tonic/Cargo.toml
+++ b/madsim-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic"
-version = "0.5.0+0.12.0"
+version = "0.5.1+0.12.0"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tonic` simulator on madsim."

--- a/madsim-tonic/src/sim.rs
+++ b/madsim-tonic/src/sim.rs
@@ -1,7 +1,7 @@
 pub use self::codec::Streaming;
 pub use tonic::{
-    async_trait, metadata, service, Code, Extensions, IntoRequest, IntoStreamingRequest, Request,
-    Response, Status,
+    async_trait, body, metadata, service, Code, Extensions, IntoRequest, IntoStreamingRequest,
+    Request, Response, Status,
 };
 
 #[macro_export]

--- a/madsim-tonic/src/transport/server.rs
+++ b/madsim-tonic/src/transport/server.rs
@@ -110,13 +110,6 @@ impl<L> Server<L> {
         self
     }
 
-    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
-    #[must_use]
-    pub fn http2_max_pending_accept_reset_streams(self, _max: Option<usize>) -> Self {
-        // ignore this setting
-        self
-    }
-
     /// Set whether HTTP2 Ping frames are enabled on accepted connections.
     #[must_use]
     pub fn http2_keepalive_interval(self, _http2_keepalive_interval: Option<Duration>) -> Self {
@@ -127,6 +120,20 @@ impl<L> Server<L> {
     /// Sets a timeout for receiving an acknowledgement of the keepalive ping.
     #[must_use]
     pub fn http2_keepalive_timeout(self, _http2_keepalive_timeout: Option<Duration>) -> Self {
+        // ignore this setting
+        self
+    }
+
+    /// Sets whether to use an adaptive flow control. Defaults to false.
+    #[must_use]
+    pub fn http2_adaptive_window(self, _enabled: Option<bool>) -> Self {
+        // ignore this setting
+        self
+    }
+
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    #[must_use]
+    pub fn http2_max_pending_accept_reset_streams(self, _max: Option<usize>) -> Self {
         // ignore this setting
         self
     }

--- a/madsim-tonic/src/transport/server.rs
+++ b/madsim-tonic/src/transport/server.rs
@@ -110,6 +110,13 @@ impl<L> Server<L> {
         self
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    #[must_use]
+    pub fn http2_max_pending_accept_reset_streams(self, _max: Option<usize>) -> Self {
+        // ignore this setting
+        self
+    }
+
     /// Set whether HTTP2 Ping frames are enabled on accepted connections.
     #[must_use]
     pub fn http2_keepalive_interval(self, _http2_keepalive_interval: Option<Duration>) -> Self {


### PR DESCRIPTION
### Add missing APIs for `tonic::transport::Server::builder`

Some interfaces were included in `madsim-tonic` v0.4.1, but I didn't find it anywhere in GitHub. I suppose there were some local changes made and directly published to crates.io. 🤡 As a result, these interfaces were regressed in `madsim-tonic` v0.4.2 and v0.5.0.


### Add missing re-exports for `tonic::body`

This is a new interface introduced in `tonic` v0.12.