### PR TITLE
fix(madsim-tokio): add `try_current`

### DIFF
--- a/madsim-tokio/Cargo.toml
+++ b/madsim-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tokio"
-version = "0.2.28"
+version = "0.2.29"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tokio` simulator on madsim."

--- a/madsim-tokio/src/sim/runtime.rs
+++ b/madsim-tokio/src/sim/runtime.rs
@@ -1,6 +1,7 @@
 use madsim::task::{AbortHandle, JoinHandle};
 use spin::Mutex;
 use std::{future::Future, io};
+use tokio::runtime::TryCurrentError;
 
 /// Builds Tokio Runtime with custom configuration values.
 pub struct Builder {}
@@ -118,8 +119,13 @@ pub struct Handle;
 
 impl Handle {
     /// Returns a handle to the current runtime.
-    pub fn current() -> Handle {
+    pub fn current() -> Self {
         Handle
+    }
+
+    /// Returns a handle to the current runtime.
+    pub fn try_current() -> Result<Self, TryCurrentError> {
+        Ok(Handle)
     }
 
     /// Enters the runtime context.


### PR DESCRIPTION
Currently it's required by `sqlx` in various places, for example: https://github.com/madsim-rs/sqlx/blob/0c5c493f31f8848b3a487c6ca15ea0f9d9425462/sqlx-core/src/rt/rt_tokio/mod.rs#L4.

I have bumped the madsim tokio version as well.