### PR TITLE
Add comment clarifying import

### DIFF
--- a/madsim/src/sim/net/mod.rs
+++ b/madsim/src/sim/net/mod.rs
@@ -3,6 +3,8 @@
 //! # Examples
 //!
 //! ```
+//! // Note: the runtime is not exposed by this crate, but the example needs to be this way to compile.
+//! //       You can access the runtime from the `madsim-tokio` crate instead.
 //! use madsim::{runtime::Runtime, net::Endpoint};
 //! use std::sync::Arc;
 //! use std::net::SocketAddr;

--- a/madsim/src/sim/runtime/mod.rs
+++ b/madsim/src/sim/runtime/mod.rs
@@ -31,6 +31,8 @@ pub use self::metrics::RuntimeMetrics;
 /// [task scheduler]: crate::task
 /// [network]: crate::net
 /// [file system]: crate::fs
+///
+/// To get direct access to it, use a crate like `madsim-tokio` which exposes the Runtime
 pub struct Runtime {
     rand: rand::GlobalRng,
     task: task::Executor,


### PR DESCRIPTION
The docs currently reference internal structs, that are only accessible via different packages.
This change adds a comment to help users trying to run the examples.