### PR TITLE
fix(madsim-tokio): `try_current` should check the underlying context, to see if there's any running

### DIFF
--- a/madsim-tokio/Cargo.toml
+++ b/madsim-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tokio"
-version = "0.2.29"
+version = "0.2.30"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tokio` simulator on madsim."

--- a/madsim-tokio/src/sim/runtime.rs
+++ b/madsim-tokio/src/sim/runtime.rs
@@ -1,7 +1,7 @@
+use madsim::runtime::Handle as MadsimHandle;
 use madsim::task::{AbortHandle, JoinHandle};
 use spin::Mutex;
 use std::{future::Future, io};
-use tokio::runtime::TryCurrentError;
 
 /// Builds Tokio Runtime with custom configuration values.
 pub struct Builder {}
@@ -111,6 +111,8 @@ impl Drop for Runtime {
     }
 }
 
+pub struct TryCurrentError;
+
 /// Handle to the tokio runtime.
 ///
 /// FIXME: tasks spawned with this handle are not correctly associated with the tokio runtime.
@@ -125,7 +127,10 @@ impl Handle {
 
     /// Returns a handle to the current runtime.
     pub fn try_current() -> Result<Self, TryCurrentError> {
-        Ok(Handle)
+        match MadsimHandle::try_current() {
+            Ok(_) => Ok(Handle),
+            Err(_e) => Err(TryCurrentError),
+        }
     }
 
     /// Enters the runtime context.

--- a/madsim-tonic-build/src/prost.rs
+++ b/madsim-tonic-build/src/prost.rs
@@ -674,7 +674,7 @@ impl Builder {
 
         // generate origin
         config.out_dir(out_dir);
-        builder.compile_with_config(config, protos, includes)?;
+        builder.compile_protos_with_config(config, protos, includes)?;
 
         Ok(())
     }


### PR DESCRIPTION
Instead of just returning the mock handle, since we are reusing madsim handle, we check that one exists first in the madsim runtime context.