### PR TITLE
test: add tests to reproduce panic on task `spawn` while `drop`

### DIFF
--- a/madsim-tokio/src/sim/runtime.rs
+++ b/madsim-tokio/src/sim/runtime.rs
@@ -193,20 +193,18 @@ mod tests {
     #[allow(dead_code)]
     fn runtime_drop_and_spawn_struct_fail() {
         #[derive(Debug)]
-        struct A{}
+        struct A {}
         impl Drop for A {
             fn drop(&mut self) {
                 Handle::current().spawn(std::future::pending::<()>());
             }
         }
 
-        let a = A{};
+        let a = A {};
         let runtime = madsim::runtime::Runtime::new();
         runtime.block_on(async move {
             let rt = Runtime::new().unwrap();
-            let join_handle = rt.spawn(async move {
-                drop(a)
-            });
+            let join_handle = rt.spawn(async move { drop(a) });
             drop(rt);
 
             let err = join_handle.await.unwrap_err();
@@ -217,7 +215,7 @@ mod tests {
     #[test]
     fn runtime_drop_and_spawn_struct_succeed() {
         #[derive(Debug)]
-        struct A{}
+        struct A {}
         impl Drop for A {
             fn drop(&mut self) {
                 Handle::current().spawn(std::future::pending::<()>());
@@ -228,7 +226,7 @@ mod tests {
         runtime.block_on(async move {
             let rt = Runtime::new().unwrap();
             let join_handle = rt.spawn(async move {
-                let a = A{};
+                let a = A {};
                 drop(a)
             });
             drop(rt);

--- a/madsim-tokio/src/sim/runtime.rs
+++ b/madsim-tokio/src/sim/runtime.rs
@@ -190,6 +190,33 @@ mod tests {
     }
 
     // FIXME(kwannoel): See https://github.com/madsim-rs/madsim/issues/228
+    // #[test]
+    #[allow(dead_code)]
+    fn runtime_drop_and_spawn_struct_fail_with_try_current_task() {
+        #[derive(Debug)]
+        struct A {}
+        impl Drop for A {
+            fn drop(&mut self) {
+                if let Some(handle) = Handle::try_current().ok() {
+                    handle.spawn(std::future::pending::<()>());
+                }
+            }
+        }
+
+        let a = A {};
+        let runtime = madsim::runtime::Runtime::new();
+        runtime.block_on(async move {
+            let rt = Runtime::new().unwrap();
+            let join_handle = rt.spawn(async move { drop(a) });
+            drop(rt);
+
+            let err = join_handle.await.unwrap_err();
+            assert!(err.is_cancelled());
+        })
+    }
+
+    // FIXME(kwannoel): See https://github.com/madsim-rs/madsim/issues/228
+    // #[test]
     #[allow(dead_code)]
     fn runtime_drop_and_spawn_struct_fail() {
         #[derive(Debug)]


### PR DESCRIPTION
Reproduce https://github.com/madsim-rs/madsim/issues/228.

We instantiate a struct outside the thread, and then move it into a future. Subsequently we spawn the future in a thread, dropping the struct.

Then the panic is reproduced.

[out.log](https://github.com/user-attachments/files/17275975/out.log)

```
connection: broken pipe", details: [], metadata: MetadataMap { headers: {} }
thread '<unnamed>' panicked at /risingwave/.cargo/registry/src/index.crates.io-6f17d22bba15001f/madsim-0.2.30/src/sim/runtime/context.rs:27:44:
there is no reactor running, must be called from the context of a Madsim runtime
stack backtrace:
   0: rust_begin_unwind
             at /rustc/5affbb17153bc69a9d5d8d2faa4e399a014a211e/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/5affbb17153bc69a9d5d8d2faa4e399a014a211e/library/core/src/panicking.rs:74:14
   2: core::panicking::panic_display
             at /rustc/5affbb17153bc69a9d5d8d2faa4e399a014a211e/library/core/src/panicking.rs:264:5
   3: core::option::expect_failed
             at /rustc/5affbb17153bc69a9d5d8d2faa4e399a014a211e/library/core/src/option.rs:2030:5
   4: expect<alloc::sync::Arc<madsim::sim::task::TaskInfo, alloc::alloc::Global>>
             at /rustc/5affbb17153bc69a9d5d8d2faa4e399a014a211e/library/core/src/option.rs:933:21
   5: {closure#0}
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/madsim-0.2.30/src/sim/runtime/context.rs:27:44
   6: try_with<core::cell::RefCell<core::option::Option<alloc::sync::Arc<madsim::sim::task::TaskInfo, alloc::alloc::Global>>>, madsim::sim::runtime::context::current_task::{closure_env#0}, alloc::sync::Arc<madsim::sim::task::TaskInfo, alloc::alloc::Global>>
             at /rustc/5affbb17153bc69a9d5d8d2faa4e399a014a211e/library/std/src/thread/local.rs:283:12
   7: with<core::cell::RefCell<core::option::Option<alloc::sync::Arc<madsim::sim::task::TaskInfo, alloc::alloc::Global>>>, madsim::sim::runtime::context::current_task::{closure_env#0}, alloc::sync::Arc<madsim::sim::task::TaskInfo, alloc::alloc::Global>>
             at /rustc/5affbb17153bc69a9d5d8d2faa4e399a014a211e/library/std/src/thread/local.rs:260:9
   8: current_task
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/madsim-0.2.30/src/sim/runtime/context.rs:27:10
   9: current
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/madsim-0.2.30/src/sim/task/mod.rs:586:20
  10: spawn<sqlx_core::pool::connection::{impl#5}::return_to_pool::{async_block_env#1}<sqlx_sqlite::database::Sqlite>>
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/madsim-0.2.30/src/sim/task/mod.rs:664:5
  11: spawn<sqlx_core::pool::connection::{impl#5}::return_to_pool::{async_block_env#1}<sqlx_sqlite::database::Sqlite>>
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/madsim-tokio-0.2.30/src/sim/runtime.rs:152:9
  12: spawn<sqlx_core::pool::connection::{impl#5}::return_to_pool::{async_block_env#1}<sqlx_sqlite::database::Sqlite>>
```