### PR TITLE
fix(madsim): drop the future within the scope of `TaskEnterGuard` when a task is aborted

### DIFF
--- a/madsim-tonic-build/src/prost.rs
+++ b/madsim-tonic-build/src/prost.rs
@@ -674,7 +674,7 @@ impl Builder {
 
         // generate origin
         config.out_dir(out_dir);
-        builder.compile_protos_with_config(config, protos, includes)?;
+        builder.compile_with_config(config, protos, includes)?;
 
         Ok(())
     }

--- a/madsim-tonic-build/src/prost.rs
+++ b/madsim-tonic-build/src/prost.rs
@@ -674,7 +674,7 @@ impl Builder {
 
         // generate origin
         config.out_dir(out_dir);
-        builder.compile_with_config(config, protos, includes)?;
+        builder.compile_protos_with_config(config, protos, includes)?;
 
         Ok(())
     }

--- a/madsim/src/sim/task/mod.rs
+++ b/madsim/src/sim/task/mod.rs
@@ -630,7 +630,7 @@ impl Spawner {
         F::Output: 'static,
     {
         if self.info.killed.load(Ordering::Relaxed) {
-            panic!("spawning task on a killed node");
+            tracing::warn!("spawning task on a killed node, the task will never run");
         }
         let sender = self.sender.clone();
         let info = self.info.new_task(name);
@@ -795,8 +795,8 @@ unsafe extern "C" fn pthread_attr_init(attr: *mut libc::pthread_attr_t) -> libc:
 mod tests {
     use super::*;
     use crate::{
-        context::current_node,
-        runtime::{Handle, Runtime},
+        context::{current, current_node},
+        runtime::{init_logger, Handle, Runtime},
         time,
     };
     use std::{collections::HashSet, sync::atomic::AtomicUsize, time::Duration};
@@ -1109,8 +1109,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(dead_code)]
-    fn spawn_in_task_drop() {
+    fn spawn_in_future_drop_by_aborting_task() {
         static DROPPING_NODE: Mutex<Option<NodeId>> = Mutex::new(None);
 
         struct A;
@@ -1141,6 +1140,42 @@ mod tests {
             time::sleep(Duration::from_secs(114514)).await;
             // Check that the task spawned in `A::drop` is also under the `node` we created.
             assert_eq!(DROPPING_NODE.try_lock().unwrap().unwrap(), node_id);
+        })
+    }
+
+    #[test]
+    fn spawn_in_future_drop_by_killing_node() {
+        init_logger();
+
+        static DROPPED: Mutex<bool> = Mutex::new(false);
+
+        struct A;
+
+        impl Drop for A {
+            fn drop(&mut self) {
+                // Spawning a task on a killed node will still succeed, but the task will never run.
+                spawn(async move { unreachable!() });
+                *DROPPED.try_lock().unwrap() = true;
+            }
+        }
+
+        let runtime = Runtime::new();
+        let node = runtime.create_node().build();
+        let node_id = node.id();
+        let a = A;
+
+        runtime.block_on(async move {
+            // Since we're a single-threaded runtime, task spawning here won't run proactively.
+            // So `drop` will only be called after we call `kill` and while `await`ing the handle.
+            let join_handle = node.spawn(async move { drop(a) });
+            current(|handle| handle.kill(node_id));
+
+            let err = join_handle.await.unwrap_err();
+            assert!(err.is_cancelled());
+            assert_eq!(*DROPPED.try_lock().unwrap(), true);
+
+            // Give some time, showing that the task spawned in `A::drop` is never run.
+            time::sleep(Duration::from_secs(114514)).await;
         })
     }
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>