### PR TITLE
chore(tonic): bump `tonic-build` to 0.12.3

### DIFF
--- a/madsim-tonic-build/Cargo.toml
+++ b/madsim-tonic-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic-build"
-version = "0.5.0+0.12.0"
+version = "0.5.1+0.12.3"
 edition = "2021"
 authors = [
     "Lucio Franco <luciofranco14@gmail.com>",
@@ -21,7 +21,7 @@ proc-macro2 = "1"
 prost-build = { version = "0.13", optional = true }
 quote = "1"
 syn = "2"
-tonic-build = "0.12"
+tonic-build = "0.12.3"
 
 [features]
 compression = []

--- a/madsim-tonic-build/src/prost.rs
+++ b/madsim-tonic-build/src/prost.rs
@@ -55,7 +55,7 @@ pub fn compile_protos(proto: impl AsRef<Path>) -> io::Result<()> {
         .parent()
         .expect("proto file should reside in a directory");
 
-    self::configure().compile(&[proto_path], &[proto_dir])?;
+    self::configure().compile_protos(&[proto_path], &[proto_dir])?;
 
     Ok(())
 }
@@ -586,17 +586,17 @@ impl Builder {
     }
 
     /// Compile the .proto files and execute code generation.
-    pub fn compile(
+    pub fn compile_protos(
         self,
         protos: &[impl AsRef<Path>],
         includes: &[impl AsRef<Path>],
     ) -> io::Result<()> {
-        self.compile_with_config(Config::new(), protos, includes)
+        self.compile_protos_with_config(Config::new(), protos, includes)
     }
 
     /// Compile the .proto files and execute code generation using a
     /// custom `prost_build::Config`.
-    pub fn compile_with_config(
+    pub fn compile_protos_with_config(
         mut self,
         mut config: Config,
         protos: &[impl AsRef<Path>],


### PR DESCRIPTION
In `tonic-build` version 0.12.3, the `compile` functions has been renamed to `compile_protos`, with the original version now marked as deprecated. For simplicity, we may use a version requirement of `0.12.3` and directly remove the deprecated methods.

As a result, the interfaces are not strictly compatible with the upstream. But as long as the application wants to clean up those warnings about deprecation, we'll be compatible.