### PR TITLE
fix(rand): stub `CCRandomGenerateBytes` syscall used in `macos`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings -A clippy::result_large_err
+          args: -- -D warnings
       - name: Clippy sim
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--cfg madsim"
         with:
           command: clippy
-          args: -- -D warnings -A clippy::result_large_err
+          args: -- -D warnings
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -D warnings -A clippy::result_large_err
       - name: Clippy sim
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--cfg madsim"
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -D warnings -A clippy::result_large_err
 
   build:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(madsim)',
     'cfg(tokio_unstable)',
 ] }
+
+[workspace.lints.clippy]
+result_large_err = "allow"

--- a/madsim-macros/src/lib.rs
+++ b/madsim-macros/src/lib.rs
@@ -40,6 +40,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
     parse(input, args, false, false).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
+#[allow(clippy::doc_overindented_list_items)]
 /// Marks async function to be executed by runtime, suitable to test environment.
 ///
 /// # Example

--- a/madsim-tonic-build/src/prost.rs
+++ b/madsim-tonic-build/src/prost.rs
@@ -158,7 +158,7 @@ impl crate::Method for TonicBuildMethod {
         let convert_type = |proto_type: &str, rust_type: &str| -> TokenStream {
             if (is_google_type(proto_type) && !compile_well_known_types)
                 || rust_type.starts_with("::")
-                || NON_PATH_TYPE_ALLOWLIST.iter().any(|ty| *ty == rust_type)
+                || NON_PATH_TYPE_ALLOWLIST.contains(&rust_type)
             {
                 rust_type.parse::<TokenStream>().unwrap()
             } else if rust_type.starts_with("crate::") {

--- a/madsim/src/sim/rand.rs
+++ b/madsim/src/sim/rand.rs
@@ -269,15 +269,14 @@ unsafe extern "C" fn getentropy(buf: *mut u8, buflen: usize) -> i32 {
 ///
 /// `getentropy` is no longer used to generate random bytes in macOS, `CCRandomGenerateBytes` is used instead.
 ///
-/// Ref: <https://github.com/apple-oss-distributions/CommonCrypto/blob/main/include/CommonRandom.h>
+/// Reference:
+/// - <https://github.com/apple-oss-distributions/CommonCrypto/blob/a0ac082c490b65585ade764511acfdbf1d97bc5e/include/CommonRandom.h#L56>
+/// - <https://github.com/apple-oss-distributions/CommonCrypto/blob/0c0a068edd73f84671f1fba8c0e171caa114ee0a/lib/CommonRandom.c#L65-L85>
 #[cfg(target_os = "macos")]
 #[no_mangle]
 #[inline(never)]
-unsafe extern "C" fn CCRandomGenerateBytes(buf: *mut u8, buflen: usize) -> i32 {
-    if buflen > 256 {
-        return -1;
-    }
-    match getrandom(buf, buflen, 0) {
+unsafe extern "C" fn CCRandomGenerateBytes(bytes: *mut u8, count: usize) -> i32 {
+    match getrandom(bytes, count, 0) {
         -1 => -1,
         _ => 0,
     }

--- a/madsim/src/sim/runtime/builder.rs
+++ b/madsim/src/sim/runtime/builder.rs
@@ -21,6 +21,7 @@ pub struct Builder {
     pub allow_system_thread: bool,
 }
 
+#[allow(clippy::doc_overindented_list_items)]
 impl Builder {
     /// Create a new builder from the following environment variables:
     ///

--- a/madsim/src/sim/task/join.rs
+++ b/madsim/src/sim/task/join.rs
@@ -115,13 +115,10 @@ impl std::error::Error for JoinError {}
 
 impl From<JoinError> for io::Error {
     fn from(src: JoinError) -> io::Error {
-        io::Error::new(
-            io::ErrorKind::Other,
-            match src.is_panic {
-                false => "task was cancelled",
-                true => "task panicked",
-            },
-        )
+        io::Error::other(match src.is_panic {
+            false => "task was cancelled",
+            true => "task panicked",
+        })
     }
 }
 


### PR DESCRIPTION
Closes #236.

The current ignored test case https://github.com/madsim-rs/madsim/blob/aaa9f9a9690be703a7fc4fcdc6f7a1f2bf5cb9ad/madsim/src/sim/rand.rs#L288-L306

can pass in macOS after this fix.
<img width="761" alt="Screenshot 2025-06-05 at 23 00 17" src="https://github.com/user-attachments/assets/f2ea3ffd-84e7-47f1-aff1-0d305312eaf4" />



I also fixed some Clippy errors, while ignoring a few in CI.