### PR TITLE
fix(tonic): align compression API with latest tonic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## tonic [0.5.2] - 2025-12-03
+
+### Changed
+- Aligned compression API with latest tonic.
+
 ## madsim [0.2.34] - 2025-10-10
 
 ### Changed

--- a/madsim-tonic-build/Cargo.toml
+++ b/madsim-tonic-build/Cargo.toml
@@ -24,7 +24,6 @@ syn = "2"
 tonic-build = "0.12.3"
 
 [features]
-compression = []
 default = ["transport", "prost"]
 prost = ["prost-build"]
 transport = []

--- a/madsim-tonic-build/Cargo.toml
+++ b/madsim-tonic-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic-build"
-version = "0.5.1+0.12.3"
+version = "0.5.2+0.12.3"
 edition = "2021"
 authors = [
     "Lucio Franco <luciofranco14@gmail.com>",

--- a/madsim-tonic-build/src/client.rs
+++ b/madsim-tonic-build/src/client.rs
@@ -40,8 +40,6 @@ pub fn generate<T: Service>(
                 unused_variables,
                 dead_code,
                 missing_docs,
-                // will trigger if compression is disabled
-                clippy::let_unit_value,
             )]
             use tonic::codegen::*;
 

--- a/madsim-tonic-build/src/server.rs
+++ b/madsim-tonic-build/src/server.rs
@@ -39,31 +39,20 @@ pub fn generate<T: Service>(
     // let mod_attributes = attributes.for_mod(package);
     // let struct_attributes = attributes.for_struct(&path);
 
-    let compression_enabled = cfg!(feature = "compression");
-
-    // let compression_config_ty = if compression_enabled {
-    //     quote! { EnabledCompressionEncodings }
-    // } else {
-    //     quote! { () }
-    // };
-
-    let configure_compression_methods = if compression_enabled {
-        quote! {
-            /// Enable decompressing requests with the given encoding.
-            #[must_use]
-            pub fn accept_compressed(self, _encoding: CompressionEncoding) -> Self {
-                // self.accept_compression_encodings.enable(encoding);
-                self
-            }
-            /// Compress responses with the given encoding, if the client supports it.
-            #[must_use]
-            pub fn send_compressed(self, _encoding: CompressionEncoding) -> Self {
-                // self.send_compression_encodings.enable(encoding);
-                self
-            }
+    let configure_compression_methods = quote! {
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(self, _encoding: CompressionEncoding) -> Self {
+            // self.accept_compression_encodings.enable(encoding);
+            self
         }
-    } else {
-        quote! {}
+
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(self, _encoding: CompressionEncoding) -> Self {
+            // self.send_compression_encodings.enable(encoding);
+            self
+        }
     };
 
     let configure_max_message_size_methods = quote! {
@@ -92,8 +81,6 @@ pub fn generate<T: Service>(
                 dead_code,
                 missing_docs,
                 unused_mut,
-                // will trigger if compression is disabled
-                clippy::let_unit_value,
             )]
             use tonic::codegen::{http::uri::PathAndQuery, futures::{stream::{self, Stream, StreamExt}, future::FutureExt}, *};
 

--- a/madsim-tonic/Cargo.toml
+++ b/madsim-tonic/Cargo.toml
@@ -13,6 +13,8 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+gzip = ["tonic/gzip"]
+zstd = ["tonic/zstd"]
 tls = ["tonic/tls"]
 
 [target.'cfg(not(madsim))'.dependencies]

--- a/madsim-tonic/Cargo.toml
+++ b/madsim-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic"
-version = "0.5.1+0.12.0"
+version = "0.5.2+0.12.0"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tonic` simulator on madsim."


### PR DESCRIPTION
- There's no `compression` feature for `tonic-build` anymore. The `configure_compression_methods` will always be generated.
- Add `gzip` and `zstd` features to `madsim-tonic` that forward to `tonic`.