### PR TITLE
chore: bump tonic to 0.14 and etcd-client to 0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## tonic [0.6.0] - 2026-02-05
+
+### Changed
+- tonic: Update `tonic` and `tonic-build` to v0.13.
+- Align `tls` feature mapping with tonic v0.13 (`tls-native-roots`).
+
 ## tonic [0.5.2] - 2025-12-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tonic: Update `tonic` and `tonic-build` to v0.13.
 - Align `tls` feature mapping with tonic v0.13 (`tls-native-roots`).
 
+## etcd-client [0.7.0] - 2026-02-05
+
+### Changed
+- etcd-client: Update upstream `etcd-client` to v0.16.x (aligns tonic to v0.13.x).
+
 ## tonic [0.5.2] - 2025-12-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - tonic: Update `tonic` and `tonic-build` to v0.14.
-- etcd-client: Update upstream `etcd-client` to v0.17.x (aligns tonic to v0.14.x).
+- etcd-client: Update upstream `etcd-client` to v0.18.x (aligns tonic to v0.14.x).
 - prost: Update to v0.14.
 
 ## tonic [0.5.2] - 2025-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## tonic [0.6.0] tonic-build [0.6.0] - 2026-02-16
 
 ### Changed
-- tonic: Update `tonic` and `tonic-build` to v0.14.
-- etcd-client: Update upstream `etcd-client` to v0.18.x (aligns tonic to v0.14.x).
-- prost: Update to v0.14.
+- Update upstream `tonic` to v0.14.
+- Update upstream `tonic-build` to v0.14.
+- Update upstream `prost` to v0.14.
+
+## etcd-client [0.7.0] - 2026-02-16
+
+### Changed
+- Update upstream `etcd-client` to v0.18 (aligned with tonic v0.14).
 
 ## tonic [0.5.2] - 2025-12-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## tonic [0.6.0] - 2026-02-05
-
 ### Changed
-- tonic: Update `tonic` and `tonic-build` to v0.13.
-- Align `tls` feature mapping with tonic v0.13 (`tls-native-roots`).
-
-## etcd-client [0.7.0] - 2026-02-05
-
-### Changed
-- etcd-client: Update upstream `etcd-client` to v0.16.x (aligns tonic to v0.13.x).
+- tonic: Update `tonic` and `tonic-build` to v0.14.
+- etcd-client: Update upstream `etcd-client` to v0.17.x (aligns tonic to v0.14.x).
+- prost: Update to v0.14.
 
 ## tonic [0.5.2] - 2025-12-03
 

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-etcd-client"
-version = "0.7.0+0.17.0"
+version = "0.7.0+0.18.0"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The etcd simulator on madsim."
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(not(madsim))'.dependencies]
-etcd-client = "0.17"
+etcd-client = "0.18"
 
 [target.'cfg(madsim)'.dependencies]
 http = "1"

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-etcd-client"
-version = "0.6.0+0.14.0"
+version = "0.7.0+0.16.0"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The etcd simulator on madsim."
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(not(madsim))'.dependencies]
-etcd-client = "0.14"
+etcd-client = "0.16"
 
 [target.'cfg(madsim)'.dependencies]
 http = "1"

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-etcd-client"
-version = "0.7.0+0.16.0"
+version = "0.7.0+0.17.0"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The etcd simulator on madsim."
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(not(madsim))'.dependencies]
-etcd-client = "0.16"
+etcd-client = "0.17"
 
 [target.'cfg(madsim)'.dependencies]
 http = "1"
@@ -24,7 +24,7 @@ serde_with = "3"
 spin = "0.9"
 thiserror = "1"
 toml = "0.8"
-tonic = { version = "0.13", default-features = false, features = ["transport"] }
+tonic = { version = "0.14", default-features = false, features = ["transport"] }
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -24,7 +24,7 @@ serde_with = "3"
 spin = "0.9"
 thiserror = "1"
 toml = "0.8"
-tonic = { version = "0.12", default-features = false, features = ["transport"] }
+tonic = { version = "0.13", default-features = false, features = ["transport"] }
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1"
 

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-etcd-client"
-version = "0.7.0+0.18.0"
+version = "0.7.0+0.18"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The etcd simulator on madsim."

--- a/madsim-tonic-build/Cargo.toml
+++ b/madsim-tonic-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic-build"
-version = "0.5.2+0.12.3"
+version = "0.6.0+0.13"
 edition = "2021"
 authors = [
     "Lucio Franco <luciofranco14@gmail.com>",
@@ -21,7 +21,7 @@ proc-macro2 = "1"
 prost-build = { version = "0.13", optional = true }
 quote = "1"
 syn = "2"
-tonic-build = "0.12.3"
+tonic-build = "0.13"
 
 [features]
 default = ["transport", "prost"]

--- a/madsim-tonic-build/Cargo.toml
+++ b/madsim-tonic-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic-build"
-version = "0.6.0+0.13"
+version = "0.6.0+0.14"
 edition = "2021"
 authors = [
     "Lucio Franco <luciofranco14@gmail.com>",
@@ -18,14 +18,15 @@ license = "MIT"
 [dependencies]
 prettyplease = "0.2"
 proc-macro2 = "1"
-prost-build = { version = "0.13", optional = true }
+prost-build = { version = "0.14", optional = true }
 quote = "1"
 syn = "2"
-tonic-build = "0.13"
+tonic-build = "0.14"
+tonic-prost-build = { version = "0.14", optional = true }
 
 [features]
 default = ["transport", "prost"]
-prost = ["prost-build"]
+prost = ["prost-build", "tonic-prost-build"]
 transport = []
 
 [lints]

--- a/madsim-tonic-build/src/prost.rs
+++ b/madsim-tonic-build/src/prost.rs
@@ -39,7 +39,7 @@ pub fn configure() -> Builder {
         disable_comments: HashSet::default(),
         use_arc_self: false,
         generate_default_stubs: false,
-        builder: tonic_build::configure(),
+        builder: tonic_prost_build::configure(),
     }
 }
 
@@ -293,7 +293,7 @@ pub struct Builder {
     out_dir: Option<PathBuf>,
 
     // The original builder.
-    builder: tonic_build::Builder,
+    builder: tonic_prost_build::Builder,
 }
 
 impl Builder {
@@ -514,7 +514,7 @@ impl Builder {
 
     /// Disable service and rpc comments emission.
     pub fn disable_comments(mut self, path: impl AsRef<str>) -> Self {
-        self.builder = self.builder.disable_comments(path.as_ref());
+        self.builder = self.builder.disable_comments([path.as_ref()]);
         self.disable_comments.insert(path.as_ref().to_string());
         self
     }
@@ -530,7 +530,7 @@ impl Builder {
     ///
     /// This effectively sets prost's exported package to an empty string.
     pub fn disable_package_emission(mut self) -> Self {
-        self.builder = self.builder.disable_package_emission();
+        self.builder = self.builder.emit_package(false);
         self.emit_package = false;
         self
     }
@@ -602,7 +602,7 @@ impl Builder {
         protos: &[impl AsRef<Path>],
         includes: &[impl AsRef<Path>],
     ) -> io::Result<()> {
-        let builder = std::mem::replace(&mut self.builder, tonic_build::configure());
+        let builder = std::mem::replace(&mut self.builder, tonic_prost_build::configure());
 
         let out_dir = if let Some(out_dir) = self.out_dir.as_ref() {
             out_dir.clone()
@@ -674,7 +674,10 @@ impl Builder {
 
         // generate origin
         config.out_dir(out_dir);
-        builder.compile_protos_with_config(config, protos, includes)?;
+        // tonic-prost-build expects `protos`/`includes` to have the same element type.
+        let protos: Vec<PathBuf> = protos.iter().map(|p| p.as_ref().to_path_buf()).collect();
+        let includes: Vec<PathBuf> = includes.iter().map(|p| p.as_ref().to_path_buf()).collect();
+        builder.compile_with_config(config, &protos, &includes)?;
 
         Ok(())
     }

--- a/madsim-tonic/Cargo.toml
+++ b/madsim-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic"
-version = "0.5.2+0.12.0"
+version = "0.6.0+0.13"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tonic` simulator on madsim."
@@ -13,12 +13,22 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+# Tonic default features are always enabled via dependency defaults.
+# We only expose non-default/extra tonic features here.
+default = []
+deflate = ["tonic/deflate"]
 gzip = ["tonic/gzip"]
 zstd = ["tonic/zstd"]
-tls = ["tonic/tls"]
+
+# TLS feature set in tonic 0.13.x.
+tls = ["tls-native-roots"]
+tls-aws-lc = ["tonic/tls-aws-lc"]
+tls-native-roots = ["tonic/tls-native-roots"]
+tls-ring = ["tonic/tls-ring"]
+tls-webpki-roots = ["tonic/tls-webpki-roots"]
 
 [target.'cfg(not(madsim))'.dependencies]
-tonic = "0.12"
+tonic = { version = "0.13" }
 
 [target.'cfg(madsim)'.dependencies]
 async-stream = "0.3"
@@ -26,12 +36,9 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
 madsim = { version = "0.2.20", path = "../madsim" }
 tracing = "0.1"
-tonic = { version = "0.12", default-features = false, features = [
-    "codegen",
-    "transport",
-] }
+tonic = { version = "0.13" }
 tokio = "1"
-tower = { version = "0.4.7" }
+tower = { version = "0.5" }
 
 [lints]
 workspace = true

--- a/madsim-tonic/Cargo.toml
+++ b/madsim-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "madsim-tonic"
-version = "0.6.0+0.13"
+version = "0.6.0+0.14"
 edition = "2021"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tonic` simulator on madsim."
@@ -28,7 +28,7 @@ tls-ring = ["tonic/tls-ring"]
 tls-webpki-roots = ["tonic/tls-webpki-roots"]
 
 [target.'cfg(not(madsim))'.dependencies]
-tonic = { version = "0.13" }
+tonic = { version = "0.14" }
 
 [target.'cfg(madsim)'.dependencies]
 async-stream = "0.3"
@@ -36,7 +36,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 futures-util = "0.3"
 madsim = { version = "0.2.20", path = "../madsim" }
 tracing = "0.1"
-tonic = { version = "0.13" }
+tonic = { version = "0.14" }
 tokio = "1"
 tower = { version = "0.5" }
 

--- a/madsim-tonic/src/sim.rs
+++ b/madsim-tonic/src/sim.rs
@@ -1,7 +1,7 @@
 pub use self::codec::Streaming;
 pub use tonic::{
-    body, metadata, service, Code, Extensions, IntoRequest, IntoStreamingRequest, Request, Response,
-    Status,
+    body, metadata, service, Code, Extensions, IntoRequest, IntoStreamingRequest, Request,
+    Response, Status,
 };
 
 #[macro_export]

--- a/madsim-tonic/src/sim.rs
+++ b/madsim-tonic/src/sim.rs
@@ -1,7 +1,7 @@
 pub use self::codec::Streaming;
 pub use tonic::{
-    async_trait, body, metadata, service, Code, Extensions, IntoRequest, IntoStreamingRequest,
-    Request, Response, Status,
+    body, metadata, service, Code, Extensions, IntoRequest, IntoStreamingRequest, Request, Response,
+    Status,
 };
 
 #[macro_export]
@@ -15,6 +15,8 @@ pub mod client;
 pub mod codec;
 pub(crate) mod tower;
 pub mod transport;
+
+pub use tonic::async_trait;
 
 /// Append header to metadata.
 trait AppendMetadata {
@@ -50,6 +52,8 @@ pub mod codegen {
 
     pub use futures_util as futures;
     pub use tonic::codegen::*;
+    // Generated code does `use tonic::codegen::*;` and then uses `#[async_trait]`.
+    pub use tonic::async_trait;
 
     /// A type-erased message.
     pub type BoxMessage = Box<dyn Any + Send + Sync>;

--- a/madsim-tonic/src/transport/channel.rs
+++ b/madsim-tonic/src/transport/channel.rs
@@ -7,6 +7,7 @@ use std::{
     fmt,
     hash::Hash,
     io,
+    net::IpAddr,
     net::SocketAddr,
     str::FromStr,
     sync::{Arc, Mutex},
@@ -18,6 +19,13 @@ use tonic::{
     transport::Uri,
 };
 use tower::discover::Change;
+#[cfg(any(
+    feature = "tls-native-roots",
+    feature = "tls-webpki-roots",
+    feature = "tls-ring",
+    feature = "tls-aws-lc"
+))]
+use tonic::transport::ClientTlsConfig;
 
 /// Channel builder.
 #[derive(Debug, Clone)]
@@ -25,6 +33,9 @@ pub struct Endpoint {
     uri: Uri,
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
+    buffer_size: Option<usize>,
+    http2_max_header_list_size: Option<u32>,
+    local_address: Option<IpAddr>,
 }
 
 impl Endpoint {
@@ -69,6 +80,14 @@ impl Endpoint {
         }
     }
 
+    /// Sets the tower service default internal buffer size.
+    pub fn buffer_size(self, sz: impl Into<Option<usize>>) -> Self {
+        Endpoint {
+            buffer_size: sz.into(),
+            ..self
+        }
+    }
+
     /// Create a channel from this config.
     pub async fn connect(&self) -> Result<Channel, Error> {
         if let Some(dur) = self.connect_timeout {
@@ -88,6 +107,21 @@ impl Endpoint {
             ep: MultiEndpoint::new_one(self.clone()),
             timeout: self.timeout,
         })
+    }
+
+    /// Create a channel that connects lazily.
+    pub fn connect_lazy(&self) -> Channel {
+        Channel {
+            ep: MultiEndpoint::new_one(self.clone()),
+            timeout: self.timeout,
+        }
+    }
+
+    /// Create a channel that connects lazily using a custom connector.
+    ///
+    /// The connector is ignored in simulation mode.
+    pub fn connect_with_connector_lazy<C>(&self, _connector: C) -> Channel {
+        self.connect_lazy()
     }
 
     /// Connect to a madsim Endpoint.
@@ -123,6 +157,18 @@ impl Endpoint {
     pub fn origin(self, _origin: Uri) -> Self {
         // ignore this setting
         self
+    }
+
+    /// Configures TLS for the endpoint.
+    #[cfg(any(
+        feature = "tls-native-roots",
+        feature = "tls-webpki-roots",
+        feature = "tls-ring",
+        feature = "tls-aws-lc"
+    ))]
+    pub fn tls_config(self, _tls_config: ClientTlsConfig) -> Result<Self, Error> {
+        // ignore this setting
+        Ok(self)
     }
 
     /// Set whether TCP keepalive messages are enabled on accepted connections.
@@ -185,6 +231,52 @@ impl Endpoint {
         // ignore this setting
         self
     }
+
+    /// Sets the max size of received header frames.
+    pub fn http2_max_header_list_size(self, size: u32) -> Self {
+        Endpoint {
+            http2_max_header_list_size: Some(size),
+            ..self
+        }
+    }
+
+    /// Sets the executor used to spawn async tasks.
+    ///
+    /// The executor is ignored in simulation mode.
+    pub fn executor<E>(self, _executor: E) -> Self
+    where
+        E: Clone + Send + Sync + 'static,
+    {
+        self
+    }
+
+    /// Sets the local address used when connecting.
+    ///
+    /// The address is ignored in simulation mode.
+    pub fn local_address(self, addr: Option<IpAddr>) -> Self {
+        Endpoint {
+            local_address: addr,
+            ..self
+        }
+    }
+
+    /// Get a reference to the configured URI.
+    pub fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    pub fn get_tcp_nodelay(&self) -> bool {
+        // We don't store this option; tonic defaults to true.
+        true
+    }
+
+    pub fn get_connect_timeout(&self) -> Option<Duration> {
+        self.connect_timeout
+    }
+
+    pub fn get_tcp_keepalive(&self) -> Option<Duration> {
+        None
+    }
 }
 
 impl From<Uri> for Endpoint {
@@ -193,6 +285,9 @@ impl From<Uri> for Endpoint {
             uri,
             timeout: None,
             connect_timeout: None,
+            buffer_size: None,
+            http2_max_header_list_size: None,
+            local_address: None,
         }
     }
 }

--- a/madsim-tonic/src/transport/channel.rs
+++ b/madsim-tonic/src/transport/channel.rs
@@ -77,6 +77,8 @@ impl Endpoint {
     }
 
     /// Sets the tower service default internal buffer size.
+    ///
+    /// Note: this setting is currently ignored by the madsim transport implementation.
     pub fn buffer_size(self, sz: impl Into<Option<usize>>) -> Self {
         // ignore this setting
         let _ = sz.into();
@@ -105,6 +107,8 @@ impl Endpoint {
     }
 
     /// Create a channel that connects lazily.
+    ///
+    /// Note: madsim transport is not backed by a real HTTP/2 connection pool.
     pub fn connect_lazy(&self) -> Channel {
         Channel {
             ep: MultiEndpoint::new_one(self.clone()),
@@ -114,7 +118,7 @@ impl Endpoint {
 
     /// Create a channel that connects lazily using a custom connector.
     ///
-    /// The connector is ignored in simulation mode.
+    /// Note: the connector is currently ignored by the madsim transport implementation.
     pub fn connect_with_connector_lazy<C>(&self, _connector: C) -> Channel {
         self.connect_lazy()
     }
@@ -155,6 +159,8 @@ impl Endpoint {
     }
 
     /// Configures TLS for the endpoint.
+    ///
+    /// Note: TLS is currently ignored by the madsim transport implementation.
     #[cfg(any(
         feature = "tls-native-roots",
         feature = "tls-webpki-roots",
@@ -228,6 +234,8 @@ impl Endpoint {
     }
 
     /// Sets the max size of received header frames.
+    ///
+    /// Note: this setting is currently ignored by the madsim transport implementation.
     pub fn http2_max_header_list_size(self, size: u32) -> Self {
         // ignore this setting
         let _ = size;
@@ -236,7 +244,7 @@ impl Endpoint {
 
     /// Sets the executor used to spawn async tasks.
     ///
-    /// The executor is ignored in simulation mode.
+    /// Note: the executor is currently ignored by the madsim transport implementation.
     pub fn executor<E>(self, _executor: E) -> Self
     where
         E: Clone + Send + Sync + 'static,
@@ -246,7 +254,7 @@ impl Endpoint {
 
     /// Sets the local address used when connecting.
     ///
-    /// The address is ignored in simulation mode.
+    /// Note: the address is currently ignored by the madsim transport implementation.
     pub fn local_address(self, addr: Option<std::net::IpAddr>) -> Self {
         // ignore this setting
         let _ = addr;
@@ -258,15 +266,22 @@ impl Endpoint {
         &self.uri
     }
 
+    /// Returns whether `TCP_NODELAY` is enabled.
+    ///
+    /// Note: this always returns `true` for API compatibility.
     pub fn get_tcp_nodelay(&self) -> bool {
         // We don't store this option; tonic defaults to true.
         true
     }
 
+    /// Returns the configured connect timeout.
     pub fn get_connect_timeout(&self) -> Option<Duration> {
         self.connect_timeout
     }
 
+    /// Returns the configured TCP keepalive setting.
+    ///
+    /// Note: this always returns `None` for API compatibility.
     pub fn get_tcp_keepalive(&self) -> Option<Duration> {
         None
     }

--- a/madsim-tonic/src/transport/channel.rs
+++ b/madsim-tonic/src/transport/channel.rs
@@ -7,7 +7,6 @@ use std::{
     fmt,
     hash::Hash,
     io,
-    net::IpAddr,
     net::SocketAddr,
     str::FromStr,
     sync::{Arc, Mutex},
@@ -33,9 +32,6 @@ pub struct Endpoint {
     uri: Uri,
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
-    buffer_size: Option<usize>,
-    http2_max_header_list_size: Option<u32>,
-    local_address: Option<IpAddr>,
 }
 
 impl Endpoint {
@@ -82,10 +78,9 @@ impl Endpoint {
 
     /// Sets the tower service default internal buffer size.
     pub fn buffer_size(self, sz: impl Into<Option<usize>>) -> Self {
-        Endpoint {
-            buffer_size: sz.into(),
-            ..self
-        }
+        // ignore this setting
+        let _ = sz.into();
+        self
     }
 
     /// Create a channel from this config.
@@ -234,10 +229,9 @@ impl Endpoint {
 
     /// Sets the max size of received header frames.
     pub fn http2_max_header_list_size(self, size: u32) -> Self {
-        Endpoint {
-            http2_max_header_list_size: Some(size),
-            ..self
-        }
+        // ignore this setting
+        let _ = size;
+        self
     }
 
     /// Sets the executor used to spawn async tasks.
@@ -253,11 +247,10 @@ impl Endpoint {
     /// Sets the local address used when connecting.
     ///
     /// The address is ignored in simulation mode.
-    pub fn local_address(self, addr: Option<IpAddr>) -> Self {
-        Endpoint {
-            local_address: addr,
-            ..self
-        }
+    pub fn local_address(self, addr: Option<std::net::IpAddr>) -> Self {
+        // ignore this setting
+        let _ = addr;
+        self
     }
 
     /// Get a reference to the configured URI.
@@ -285,9 +278,6 @@ impl From<Uri> for Endpoint {
             uri,
             timeout: None,
             connect_timeout: None,
-            buffer_size: None,
-            http2_max_header_list_size: None,
-            local_address: None,
         }
     }
 }

--- a/madsim-tonic/src/transport/channel.rs
+++ b/madsim-tonic/src/transport/channel.rs
@@ -13,11 +13,6 @@ use std::{
     time::Duration,
 };
 use tokio::sync::mpsc::{channel, Receiver, Sender};
-use tonic::{
-    codegen::{http::HeaderValue, Bytes, StdError},
-    transport::Uri,
-};
-use tower::discover::Change;
 #[cfg(any(
     feature = "tls-native-roots",
     feature = "tls-webpki-roots",
@@ -25,6 +20,11 @@ use tower::discover::Change;
     feature = "tls-aws-lc"
 ))]
 use tonic::transport::ClientTlsConfig;
+use tonic::{
+    codegen::{http::HeaderValue, Bytes, StdError},
+    transport::Uri,
+};
+use tower::discover::Change;
 
 /// Channel builder.
 #[derive(Debug, Clone)]

--- a/madsim-tonic/src/transport/server.rs
+++ b/madsim-tonic/src/transport/server.rs
@@ -68,7 +68,8 @@ impl<L> Server<L> {
 
     /// Create a router with the optional `S` typed service as the first service.
     ///
-    /// When `None`, this returns an empty router (requests will return Unimplemented).
+    /// When `None`, this returns an empty router (requests will return
+    /// [`Code::Unimplemented`]).
     pub fn add_optional_service<S>(&mut self, svc: Option<S>) -> Router<L>
     where
         S: Service<
@@ -182,6 +183,8 @@ impl<L> Server<L> {
     }
 
     /// Sets the maximum time a connection may exist.
+    ///
+    /// Note: this setting is currently ignored by the madsim transport implementation.
     #[must_use]
     pub fn max_connection_age(self, _max_connection_age: Duration) -> Self {
         // ignore this setting
@@ -189,6 +192,8 @@ impl<L> Server<L> {
     }
 
     /// Sets the max size of received header frames.
+    ///
+    /// Note: this setting is currently ignored by the madsim transport implementation.
     #[must_use]
     pub fn http2_max_header_list_size(self, _max: impl Into<Option<u32>>) -> Self {
         // ignore this setting
@@ -224,6 +229,8 @@ impl<L> Server<L> {
     }
 
     /// Intercept inbound headers and add a tracing span to each response future.
+    ///
+    /// Note: this setting is currently ignored by the madsim transport implementation.
     #[must_use]
     pub fn trace_fn<FN>(self, _f: FN) -> Self
     where
@@ -273,6 +280,8 @@ impl<L> Router<L> {
     }
 
     /// Add an optional service to this router.
+    ///
+    /// When `None`, this leaves the router unchanged.
     pub fn add_optional_service<S>(self, svc: Option<S>) -> Self
     where
         S: Service<

--- a/madsim-tonic/src/transport/server.rs
+++ b/madsim-tonic/src/transport/server.rs
@@ -16,7 +16,12 @@ use std::{
     time::Duration,
 };
 use tonic::codegen::{http::uri::PathAndQuery, BoxFuture, Service};
-#[cfg(feature = "tls")]
+#[cfg(any(
+    feature = "tls-native-roots",
+    feature = "tls-webpki-roots",
+    feature = "tls-ring",
+    feature = "tls-aws-lc"
+))]
 use tonic::transport::ServerTlsConfig;
 use tracing::*;
 
@@ -61,6 +66,31 @@ impl<L> Server<L> {
         router.add_service(svc)
     }
 
+    /// Create a router with the optional `S` typed service as the first service.
+    ///
+    /// When `None`, this returns an empty router (requests will return Unimplemented).
+    pub fn add_optional_service<S>(&mut self, svc: Option<S>) -> Router<L>
+    where
+        S: Service<
+                (PathAndQuery, Request<BoxMessageStream>),
+                Response = Response<BoxMessageStream>,
+                Error = Status,
+                Future = BoxFuture<Response<BoxMessageStream>, Status>,
+            > + NamedService
+            + Send
+            + 'static,
+        L: Clone,
+    {
+        let router = Router {
+            server: self.clone(),
+            services: Default::default(),
+        };
+        match svc {
+            Some(svc) => router.add_service(svc),
+            None => router,
+        }
+    }
+
     /// Set the Tower Layer all services will be wrapped in.
     pub fn layer<NewLayer>(self, _new_layer: NewLayer) -> Server<Stack<NewLayer, L>> {
         tracing::warn!("layer is unimplemented and ignored");
@@ -68,8 +98,21 @@ impl<L> Server<L> {
     }
 
     /// Configure TLS for this server.
-    #[cfg(feature = "tls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    #[cfg(any(
+        feature = "tls-native-roots",
+        feature = "tls-webpki-roots",
+        feature = "tls-ring",
+        feature = "tls-aws-lc"
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "tls-native-roots",
+            feature = "tls-webpki-roots",
+            feature = "tls-ring",
+            feature = "tls-aws-lc"
+        )))
+    )]
     pub fn tls_config(self, _tls_config: ServerTlsConfig) -> Result<Self, Error> {
         // ignore this setting
         Ok(self)
@@ -138,6 +181,20 @@ impl<L> Server<L> {
         self
     }
 
+    /// Sets the maximum time a connection may exist.
+    #[must_use]
+    pub fn max_connection_age(self, _max_connection_age: Duration) -> Self {
+        // ignore this setting
+        self
+    }
+
+    /// Sets the max size of received header frames.
+    #[must_use]
+    pub fn http2_max_header_list_size(self, _max: impl Into<Option<u32>>) -> Self {
+        // ignore this setting
+        self
+    }
+
     /// Set whether TCP keepalive messages are enabled on accepted connections.
     #[must_use]
     pub fn tcp_keepalive(self, _tcp_keepalive: Option<Duration>) -> Self {
@@ -162,6 +219,16 @@ impl<L> Server<L> {
     /// Allow this server to accept http1 requests.
     #[must_use]
     pub fn accept_http1(self, _accept_http1: bool) -> Self {
+        // ignore this setting
+        self
+    }
+
+    /// Intercept inbound headers and add a tracing span to each response future.
+    #[must_use]
+    pub fn trace_fn<FN>(self, _f: FN) -> Self
+    where
+        FN: Fn(&tonic::codegen::http::Request<()>) -> tracing::Span + Send + Sync + 'static,
+    {
         // ignore this setting
         self
     }
@@ -203,6 +270,24 @@ impl<L> Router<L> {
     {
         self.services.insert(S::NAME, Box::new(svc));
         self
+    }
+
+    /// Add an optional service to this router.
+    pub fn add_optional_service<S>(self, svc: Option<S>) -> Self
+    where
+        S: Service<
+                (PathAndQuery, Request<BoxMessageStream>),
+                Response = Response<BoxMessageStream>,
+                Error = Status,
+                Future = BoxFuture<Response<BoxMessageStream>, Status>,
+            > + NamedService
+            + Send
+            + 'static,
+    {
+        match svc {
+            Some(svc) => self.add_service(svc),
+            None => self,
+        }
     }
 
     /// Consume this [`Server`] creating a future that will execute the server

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -17,7 +17,7 @@ default = ["macros", "rpc"]
 ucx = ["async-ucx"]
 rpc = ["bincode"]
 macros = ["madsim-macros", "tokio/macros"]
-erpc = ["rpc"] # placeholder; enables building the `erpc` example
+# erpc = ["rpc"] # "mad_rpc"
 
 [dependencies]
 bincode = { version = "1", optional = true }

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -17,7 +17,7 @@ default = ["macros", "rpc"]
 ucx = ["async-ucx"]
 rpc = ["bincode"]
 macros = ["madsim-macros", "tokio/macros"]
-# erpc = ["rpc"] # "mad_rpc"
+erpc = ["rpc"] # placeholder; enables building the `erpc` example
 
 [dependencies]
 bincode = { version = "1", optional = true }

--- a/tonic-example/Cargo.toml
+++ b/tonic-example/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2021"
 async-stream = "0.3"
 futures-core = "0.3"
 madsim = { path = "../madsim" }
-prost = "0.13"
+prost = "0.14"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tonic = { path = "../madsim-tonic", package = "madsim-tonic" }
+tonic-prost = "0.14"
 tracing-subscriber = "0.3"
 
 [build-dependencies]


### PR DESCRIPTION
## Summary
- bump `madsim-tonic` and `madsim-tonic-build` to `0.6.0+0.14`
- bump `madsim-etcd-client` to `0.7.0+0.18.0`