### PR TITLE
Enable support for Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.85"
+
 [patch.crates-io]
 getrandom = { git = "https://github.com/madsim-rs/getrandom.git", rev = "6c9d9e9" }
 

--- a/madsim-aws-sdk-s3/Cargo.toml
+++ b/madsim-aws-sdk-s3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim-aws-sdk-s3"
 version = "0.5.0+1"
-edition = "2021"
+edition = "2024"
 authors = ["Kevin Axel <kevinaxel@163.com>"]
 description = "The s3 simulator on madsim."
 homepage = "https://github.com/madsim-rs/madsim"

--- a/madsim-aws-sdk-s3/src/operation/abort_multipart_upload.rs
+++ b/madsim-aws-sdk-s3/src/operation/abort_multipart_upload.rs
@@ -5,7 +5,7 @@ pub use aws_sdk_s3::operation::abort_multipart_upload::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::abort_multipart_upload::builders::{
         AbortMultipartUploadInputBuilder, AbortMultipartUploadOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/complete_multipart_upload.rs
+++ b/madsim-aws-sdk-s3/src/operation/complete_multipart_upload.rs
@@ -5,7 +5,7 @@ pub use aws_sdk_s3::operation::complete_multipart_upload::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::complete_multipart_upload::builders::{
         CompleteMultipartUploadInputBuilder, CompleteMultipartUploadOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/create_multipart_upload.rs
+++ b/madsim-aws-sdk-s3/src/operation/create_multipart_upload.rs
@@ -5,7 +5,7 @@ pub use aws_sdk_s3::operation::create_multipart_upload::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::create_multipart_upload::builders::{
         CreateMultipartUploadInputBuilder, CreateMultipartUploadOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/delete_object.rs
+++ b/madsim-aws-sdk-s3/src/operation/delete_object.rs
@@ -5,7 +5,7 @@ pub use aws_sdk_s3::operation::delete_object::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::delete_object::builders::{
         DeleteObjectInputBuilder, DeleteObjectOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/delete_objects.rs
+++ b/madsim-aws-sdk-s3/src/operation/delete_objects.rs
@@ -5,7 +5,7 @@ pub use aws_sdk_s3::operation::delete_objects::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::delete_objects::builders::{
         DeleteObjectsInputBuilder, DeleteObjectsOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/get_bucket_lifecycle_configuration.rs
+++ b/madsim-aws-sdk-s3/src/operation/get_bucket_lifecycle_configuration.rs
@@ -6,7 +6,7 @@ pub use aws_sdk_s3::operation::get_bucket_lifecycle_configuration::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::get_bucket_lifecycle_configuration::builders::{
         GetBucketLifecycleConfigurationInputBuilder, GetBucketLifecycleConfigurationOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/get_object.rs
+++ b/madsim-aws-sdk-s3/src/operation/get_object.rs
@@ -3,7 +3,7 @@ pub use aws_sdk_s3::operation::get_object::{GetObjectError, GetObjectInput, GetO
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::get_object::builders::{
         GetObjectInputBuilder, GetObjectOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/head_object.rs
+++ b/madsim-aws-sdk-s3/src/operation/head_object.rs
@@ -3,7 +3,7 @@ pub use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectInput, H
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::head_object::builders::{
         HeadObjectInputBuilder, HeadObjectOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/list_objects_v2.rs
+++ b/madsim-aws-sdk-s3/src/operation/list_objects_v2.rs
@@ -5,7 +5,7 @@ pub use aws_sdk_s3::operation::list_objects_v2::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::list_objects_v2::builders::{
         ListObjectsV2InputBuilder, ListObjectsV2OutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/put_bucket_lifecycle_configuration.rs
+++ b/madsim-aws-sdk-s3/src/operation/put_bucket_lifecycle_configuration.rs
@@ -6,7 +6,7 @@ pub use aws_sdk_s3::operation::put_bucket_lifecycle_configuration::{
 pub mod builders {
     use super::*;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::put_bucket_lifecycle_configuration::builders::{
         PutBucketLifecycleConfigurationInputBuilder, PutBucketLifecycleConfigurationOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/put_object.rs
+++ b/madsim-aws-sdk-s3/src/operation/put_object.rs
@@ -4,7 +4,7 @@ pub mod builders {
     use super::*;
     use crate::primitives::ByteStream;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::put_object::builders::{
         PutObjectInputBuilder, PutObjectOutputBuilder,

--- a/madsim-aws-sdk-s3/src/operation/upload_part.rs
+++ b/madsim-aws-sdk-s3/src/operation/upload_part.rs
@@ -4,7 +4,7 @@ pub mod builders {
     use super::*;
     use crate::primitives::ByteStream;
     use crate::server::service::Request;
-    use crate::{error::SdkError, Client};
+    use crate::{Client, error::SdkError};
 
     pub use aws_sdk_s3::operation::upload_part::builders::{
         UploadPartInputBuilder, UploadPartOutputBuilder,

--- a/madsim-aws-sdk-s3/src/server/service.rs
+++ b/madsim-aws-sdk-s3/src/server/service.rs
@@ -1,10 +1,10 @@
 use bytes::Bytes;
 use madsim::export::futures::FutureExt;
-use madsim::rand::{thread_rng, Rng};
+use madsim::rand::{Rng, thread_rng};
 use spin::Mutex;
 use tracing::debug;
 
-use std::collections::{btree_map::Entry::*, BTreeMap};
+use std::collections::{BTreeMap, btree_map::Entry::*};
 
 use crate::operation::abort_multipart_upload::*;
 use crate::operation::complete_multipart_upload::*;
@@ -254,7 +254,7 @@ impl ServiceInner {
             .or_default();
 
         loop {
-            let upload_id = thread_rng().gen::<u32>().to_string();
+            let upload_id = thread_rng().r#gen::<u32>().to_string();
             if object.parts.contains_key(&upload_id) {
                 continue;
             } else {
@@ -288,7 +288,7 @@ impl ServiceInner {
             .get_mut(&upload_id)
             .ok_or_else(|| UploadPartError::unhandled(no_such_upload(&upload_id)))?;
 
-        let e_tag = thread_rng().gen::<u32>().to_string();
+        let e_tag = thread_rng().r#gen::<u32>().to_string();
         let part = ObjectPart {
             part_number,
             body,

--- a/madsim-etcd-client/Cargo.toml
+++ b/madsim-etcd-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim-etcd-client"
 version = "0.6.0+0.14.0"
-edition = "2021"
+edition = "2024"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The etcd simulator on madsim."
 homepage = "https://github.com/madsim-rs/madsim"

--- a/madsim-etcd-client/src/bytes.rs
+++ b/madsim-etcd-client/src/bytes.rs
@@ -1,4 +1,4 @@
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use std::fmt::{self, Debug, Display};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;

--- a/madsim-etcd-client/src/election.rs
+++ b/madsim-etcd-client/src/election.rs
@@ -1,4 +1,4 @@
-use super::{server::Request, Bytes, KeyValue, ResponseHeader, Result};
+use super::{Bytes, KeyValue, ResponseHeader, Result, server::Request};
 use futures_util::stream::{Stream, StreamExt};
 use madsim::net::{Endpoint, Receiver};
 use std::{

--- a/madsim-etcd-client/src/kv.rs
+++ b/madsim-etcd-client/src/kv.rs
@@ -1,4 +1,4 @@
-use super::{server::Request, Bytes, ResponseHeader, Result};
+use super::{Bytes, ResponseHeader, Result, server::Request};
 use madsim::net::Endpoint;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, net::SocketAddr};

--- a/madsim-etcd-client/src/lease.rs
+++ b/madsim-etcd-client/src/lease.rs
@@ -1,4 +1,4 @@
-use super::{server::Request, ResponseHeader, Result};
+use super::{ResponseHeader, Result, server::Request};
 use futures_util::stream::{Stream, StreamExt};
 use madsim::net::{Endpoint, Receiver, Sender};
 use std::{

--- a/madsim-etcd-client/src/maintenance.rs
+++ b/madsim-etcd-client/src/maintenance.rs
@@ -1,4 +1,4 @@
-use super::{server::Request, ResponseHeader, Result};
+use super::{ResponseHeader, Result, server::Request};
 use madsim::net::Endpoint;
 use std::net::SocketAddr;
 

--- a/madsim-etcd-client/src/server.rs
+++ b/madsim-etcd-client/src/server.rs
@@ -1,8 +1,8 @@
-use futures_util::{select_biased, FutureExt};
+use futures_util::{FutureExt, select_biased};
 use madsim::net::{Endpoint, Payload};
 use std::{io::Result, net::SocketAddr, sync::Arc};
 
-use super::{election::*, kv::*, service::EtcdService, Bytes};
+use super::{Bytes, election::*, kv::*, service::EtcdService};
 
 /// A simulated etcd server.
 #[derive(Default, Clone)]

--- a/madsim-etcd-client/src/service.rs
+++ b/madsim-etcd-client/src/service.rs
@@ -1,10 +1,10 @@
 use super::*;
-use madsim::rand::{random, thread_rng, Rng};
+use madsim::rand::{Rng, random, thread_rng};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
+use serde_with::{DisplayFromStr, serde_as};
 use spin::Mutex;
 use std::collections::btree_map::Entry;
-use std::collections::{btree_map::Range, BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, btree_map::Range};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 

--- a/madsim-macros/Cargo.toml
+++ b/madsim-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim-macros"
 version = "0.2.12"
-edition = "2021"
+edition = "2024"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Madsim's proc-macro."
 homepage = "https://github.com/madsim-rs/madsim"
@@ -14,7 +14,7 @@ categories = ["asynchronous"]
 proc-macro = true
 
 [dependencies]
-darling = "0.14"
+darling = "0.20"
 proc-macro2 = "1"
 quote = "1"
-syn = "1"
+syn = { version = "2", features = ["full"] }

--- a/madsim-macros/src/lib.rs
+++ b/madsim-macros/src/lib.rs
@@ -33,11 +33,9 @@ pub fn service(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn main(_args: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
-    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
-
-    parse(input, args, false, false).unwrap_or_else(|e| e.to_compile_error().into())
+    parse(input, false, false).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 #[allow(clippy::doc_overindented_list_items)]
@@ -86,39 +84,28 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 ///     By default, it is disabled.
 #[proc_macro_attribute]
-pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn test(_args: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
-    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
-
-    parse(input, args, true, false).unwrap_or_else(|e| e.to_compile_error().into())
+    parse(input, true, false).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 // This macro is used by madsim-tokio.
 #[doc(hidden)]
 #[proc_macro_attribute]
-pub fn tokio_main(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn tokio_main(_args: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
-    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
-
-    parse(input, args, false, true).unwrap_or_else(|e| e.to_compile_error().into())
+    parse(input, false, true).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 // This macro is used by madsim-tokio.
 #[doc(hidden)]
 #[proc_macro_attribute]
-pub fn tokio_test(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn tokio_test(_args: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
-    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
-
-    parse(input, args, true, true).unwrap_or_else(|e| e.to_compile_error().into())
+    parse(input, true, true).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
-fn parse(
-    mut input: syn::ItemFn,
-    _args: syn::AttributeArgs,
-    is_test: bool,
-    is_tokio: bool,
-) -> Result<TokenStream, syn::Error> {
+fn parse(mut input: syn::ItemFn, is_test: bool, is_tokio: bool) -> Result<TokenStream, syn::Error> {
     if input.sig.asyncness.take().is_none() {
         let msg = "the `async` keyword is missing from the function declaration";
         return Err(syn::Error::new_spanned(input.sig.fn_token, msg));
@@ -133,7 +120,8 @@ fn parse(
     };
     input.block = syn::parse2(quote! {
         {
-            #tokio::madsim::runtime::Builder::from_env().run(|| async #body)
+            async fn __madsim_test_body() #body
+            #tokio::madsim::runtime::Builder::from_env().run(__madsim_test_body)
         }
     })
     .expect("Parsing failure");

--- a/madsim-macros/src/request.rs
+++ b/madsim-macros/src/request.rs
@@ -25,7 +25,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 
 pub const MESSAGE_ATTR: &str = "rtype";
 
@@ -43,7 +43,7 @@ pub fn expand(ast: &syn::DeriveInput) -> TokenStream {
                             ty.len()
                         ),
                     )
-                    .to_compile_error()
+                    .to_compile_error();
                 }
             },
             Err(err) => return err.to_compile_error(),
@@ -69,64 +69,74 @@ fn get_attribute_type_multiple(
     ast: &syn::DeriveInput,
     name: &str,
 ) -> syn::Result<Vec<Option<syn::Type>>> {
+    use syn::parse::Parser;
+
     let attr = ast
         .attrs
         .iter()
-        .find_map(|a| {
-            let a = a.parse_meta();
-            match a {
-                Ok(meta) => {
-                    if meta.path().is_ident(name) {
-                        Some(meta)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            }
-        })
+        .find(|a| a.path().is_ident(name))
         .ok_or_else(|| {
             syn::Error::new(Span::call_site(), format!("Expect an attribute `{name}`"))
         })?;
 
-    if let syn::Meta::List(ref list) = attr {
-        Ok(list
-            .nested
-            .iter()
-            .map(|m| meta_item_to_ty(m).ok())
-            .collect())
-    } else {
-        Err(syn::Error::new_spanned(
-            attr,
-            format!("The correct syntax is #[{name}(type, type, ...)]"),
-        ))
-    }
+    // Parse the content inside the parentheses
+    let parser = |input: syn::parse::ParseStream| {
+        let mut types = Vec::new();
+        while !input.is_empty() {
+            let ty = parse_type_arg(input)?;
+            types.push(ty);
+            if input.peek(syn::Token![,]) {
+                input.parse::<syn::Token![,]>()?;
+            }
+        }
+        Ok(types)
+    };
+
+    let tokens = match &attr.meta {
+        syn::Meta::List(list) => list.tokens.clone(),
+        _ => {
+            return Err(syn::Error::new_spanned(
+                attr,
+                format!("The correct syntax is #[{name}(type, type, ...)]"),
+            ));
+        }
+    };
+
+    parser.parse2(tokens)
 }
 
-fn meta_item_to_ty(meta_item: &syn::NestedMeta) -> syn::Result<syn::Type> {
-    match meta_item {
-        syn::NestedMeta::Meta(syn::Meta::Path(ref path)) => match path.get_ident() {
-            Some(ident) => syn::parse_str::<syn::Type>(&ident.to_string())
-                .map_err(|_| syn::Error::new_spanned(ident, "Expect type")),
-            None => Err(syn::Error::new_spanned(path, "Expect type")),
-        },
-        syn::NestedMeta::Meta(syn::Meta::NameValue(val)) => match val.path.get_ident() {
-            Some(ident) if ident == "result" => {
-                if let syn::Lit::Str(ref s) = val.lit {
-                    if let Ok(ty) = syn::parse_str::<syn::Type>(&s.value()) {
-                        return Ok(ty);
-                    }
-                }
-                Err(syn::Error::new_spanned(&val.lit, "Expect type"))
-            }
-            _ => Err(syn::Error::new_spanned(
-                &val.lit,
+fn parse_type_arg(input: syn::parse::ParseStream) -> syn::Result<Option<syn::Type>> {
+    // Handle `result = "TYPE"` syntax
+    if input.peek(syn::Ident) && input.peek2(syn::Token![=]) {
+        let ident: syn::Ident = input.parse()?;
+        if ident != "result" {
+            return Err(syn::Error::new_spanned(
+                ident,
                 r#"Expect `result = "TYPE"`"#,
-            )),
-        },
-        syn::NestedMeta::Lit(syn::Lit::Str(ref s)) => syn::parse_str::<syn::Type>(&s.value())
-            .map_err(|_| syn::Error::new_spanned(s, "Expect type")),
-
-        meta => Err(syn::Error::new_spanned(meta, "Expect type")),
+            ));
+        }
+        input.parse::<syn::Token![=]>()?;
+        let s: syn::LitStr = input.parse()?;
+        let ty = syn::parse_str::<syn::Type>(&s.value())
+            .map_err(|_| syn::Error::new_spanned(&s, "Expect type"))?;
+        return Ok(Some(ty));
     }
+
+    // Handle string literal like `"String"`
+    if input.peek(syn::LitStr) {
+        let s: syn::LitStr = input.parse()?;
+        let ty = syn::parse_str::<syn::Type>(&s.value())
+            .map_err(|_| syn::Error::new_spanned(&s, "Expect type"))?;
+        return Ok(Some(ty));
+    }
+
+    // Handle plain identifier like `MyType`
+    if input.peek(syn::Ident) {
+        let ident: syn::Ident = input.parse()?;
+        let ty = syn::parse_str::<syn::Type>(&ident.to_string())
+            .map_err(|_| syn::Error::new_spanned(&ident, "Expect type"))?;
+        return Ok(Some(ty));
+    }
+
+    Err(input.error("Expect type"))
 }

--- a/madsim-macros/src/service.rs
+++ b/madsim-macros/src/service.rs
@@ -32,11 +32,11 @@ fn take_rpc_attributes(input: &mut ItemImpl) -> Result<Vec<RpcFn>> {
     let mut fns = vec![];
     for item in &mut input.items {
         let method = match item {
-            ImplItem::Method(m) => m,
+            ImplItem::Fn(m) => m,
             _ => continue,
         };
         let rpc_meta = match take_attribute(&mut method.attrs, "rpc") {
-            Some(v) => v.parse_meta().unwrap(),
+            Some(v) => v.meta.clone(),
             _ => continue,
         };
         let mut rpc_fn = RpcFn::try_from(&method.sig)?;
@@ -113,7 +113,7 @@ fn take_attribute(attrs: &mut Vec<Attribute>, path: &str) -> Option<Attribute> {
     attrs
         .iter()
         .position(|attr| {
-            attr.path
+            attr.path()
                 .get_ident()
                 .map(|ident| ident == path)
                 .unwrap_or(false)

--- a/madsim-rdkafka/Cargo.toml
+++ b/madsim-rdkafka/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim-rdkafka"
 version = "0.4.4+0.34.0"
-edition = "2021"
+edition = "2024"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The rdkafka simulator on madsim."
 homepage = "https://github.com/madsim-rs/madsim"

--- a/madsim-rdkafka/src/lib.rs
+++ b/madsim-rdkafka/src/lib.rs
@@ -1,4 +1,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Allow the legacy behavior for unsafe operations in unsafe functions.
+// This is FFI code from rdkafka that requires extensive changes to properly
+// wrap all unsafe operations.
+#![allow(unsafe_op_in_unsafe_fn)]
 
 #[cfg(madsim)]
 mod sim;

--- a/madsim-rdkafka/src/sim/admin.rs
+++ b/madsim-rdkafka/src/sim/admin.rs
@@ -27,13 +27,13 @@ use madsim::net::Endpoint;
 use serde::Deserialize;
 
 use crate::{
+    ClientConfig,
     client::{ClientContext, DefaultClientContext},
     config::{FromClientConfig, FromClientConfigAndContext},
     error::{KafkaError, KafkaResult},
     sim_broker::Request,
     types::RDKafkaErrorCode,
     util::Timeout,
-    ClientConfig,
 };
 
 pub struct AdminClient<C: ClientContext> {

--- a/madsim-rdkafka/src/sim/broker.rs
+++ b/madsim-rdkafka/src/sim/broker.rs
@@ -1,10 +1,10 @@
 //! A simulated Kafka broker.
 
 use crate::{
+    Message, Offset, TopicPartitionList,
     error::{KafkaError as Error, KafkaResult as Result, RDKafkaErrorCode as ErrorCode},
     message::{OwnedMessage, Timestamp},
     metadata::{Metadata, MetadataPartition, MetadataTopic},
-    Message, Offset, TopicPartitionList,
 };
 use std::collections::HashMap;
 use tracing::*;

--- a/madsim-rdkafka/src/sim/client.rs
+++ b/madsim-rdkafka/src/sim/client.rs
@@ -1,6 +1,6 @@
+use crate::Statistics;
 use crate::config::RDKafkaLogLevel;
 use crate::error::KafkaError;
-use crate::Statistics;
 use std::error::Error;
 use tracing::*;
 

--- a/madsim-rdkafka/src/sim/config.rs
+++ b/madsim-rdkafka/src/sim/config.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::{error::KafkaResult, ClientContext};
+use crate::{ClientContext, error::KafkaResult};
 
 /// The log levels supported by librdkafka.
 #[derive(Copy, Clone, Debug)]

--- a/madsim-rdkafka/src/sim/consumer.rs
+++ b/madsim-rdkafka/src/sim/consumer.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use crate::{
+    ClientConfig, Offset, TopicPartitionList,
     broker::FetchOptions,
     client::ClientContext,
     config::{FromClientConfig, FromClientConfigAndContext},
@@ -23,7 +24,6 @@ use crate::{
     sim_broker::Request,
     topic_partition_list::Elem,
     util::Timeout,
-    ClientConfig, Offset, TopicPartitionList,
 };
 
 /// Common trait for all consumers.
@@ -868,10 +868,11 @@ mod tests {
         {
             let tpl = consumer.tpl.lock();
             assert_eq!(tpl.count(), 1);
-            assert!(tpl
-                .list
-                .iter()
-                .all(|elem| !(elem.topic == "topic" && elem.partition == 1)));
+            assert!(
+                tpl.list
+                    .iter()
+                    .all(|elem| !(elem.topic == "topic" && elem.partition == 1))
+            );
         }
 
         // Removing a non-existent partition should be a no-op.

--- a/madsim-rdkafka/src/sim/error.rs
+++ b/madsim-rdkafka/src/sim/error.rs
@@ -61,14 +61,14 @@ impl fmt::Display for KafkaError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             KafkaError::AdminOp(err) => write!(f, "Admin operation error: {err}"),
-            KafkaError::AdminOpCreation(ref err) => {
+            KafkaError::AdminOpCreation(err) => {
                 write!(f, "Admin operation creation error: {err}")
             }
             KafkaError::Canceled => write!(f, "KafkaError (Client dropped)"),
             // KafkaError::ClientConfig(_, ref desc, ref key, ref value) => {
             //     write!(f, "Client config error: {} {} {}", desc, key, value)
             // }
-            KafkaError::ClientCreation(ref err) => write!(f, "Client creation error: {err}"),
+            KafkaError::ClientCreation(err) => write!(f, "Client creation error: {err}"),
             KafkaError::ConsumerCommit(err) => write!(f, "Consumer commit error: {err}"),
             KafkaError::Flush(err) => write!(f, "KafkaError (Flush error: {err})"),
             KafkaError::Global(err) => write!(f, "Global error: {err}"),

--- a/madsim-rdkafka/src/sim/producer/base_producer.rs
+++ b/madsim-rdkafka/src/sim/producer/base_producer.rs
@@ -6,12 +6,12 @@ use tracing::*;
 
 use super::{DefaultProducerContext, IntoOpaque, ProducerConfig, ProducerContext};
 use crate::{
+    ClientConfig, Timestamp,
     config::{FromClientConfig, FromClientConfigAndContext},
     error::{KafkaError, KafkaResult, RDKafkaError, RDKafkaErrorCode},
     message::{OwnedHeaders, OwnedMessage, ToBytes},
     sim_broker::Request,
     util::Timeout,
-    ClientConfig, Timestamp,
 };
 
 /// A record for the [`BaseProducer`] and [`ThreadedProducer`].

--- a/madsim-rdkafka/src/sim/producer/future_producer.rs
+++ b/madsim-rdkafka/src/sim/producer/future_producer.rs
@@ -1,11 +1,11 @@
 use super::{BaseRecord, DeliveryResult, IntoOpaque, ProducerContext, ThreadedProducer};
 use crate::{
+    ClientConfig, ClientContext, Statistics,
     client::{BrokerAddr, DefaultClientContext, OAuthToken},
     config::{FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel},
     error::{KafkaError, KafkaResult},
     message::{Message, OwnedHeaders, OwnedMessage, ToBytes},
     util::Timeout,
-    ClientConfig, ClientContext, Statistics,
 };
 use futures_channel::oneshot;
 use futures_util::FutureExt;

--- a/madsim-rdkafka/src/sim/sim_broker.rs
+++ b/madsim-rdkafka/src/sim/sim_broker.rs
@@ -1,8 +1,8 @@
 use crate::{
+    TopicPartitionList,
     broker::{Broker, FetchOptions},
     message::OwnedMessage,
     metadata::Metadata,
-    TopicPartitionList,
 };
 use madsim::net::{Endpoint, Payload};
 use spin::Mutex;

--- a/madsim-rdkafka/src/std/admin.rs
+++ b/madsim-rdkafka/src/std/admin.rs
@@ -5,11 +5,11 @@
 //! [`AdminClient`]: struct.AdminClient.html
 
 use std::collections::HashMap;
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::{CStr, CString, c_void};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -25,7 +25,7 @@ use crate::client::{Client, ClientContext, DefaultClientContext, NativeQueue};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::log::{trace, warn};
-use crate::util::{cstr_to_owned, AsCArray, ErrBuf, IntoOpaque, KafkaDrop, NativePtr, Timeout};
+use crate::util::{AsCArray, ErrBuf, IntoOpaque, KafkaDrop, NativePtr, Timeout, cstr_to_owned};
 
 //
 // ********** ADMIN CLIENT **********

--- a/madsim-rdkafka/src/std/client.rs
+++ b/madsim-rdkafka/src/std/client.rs
@@ -263,7 +263,7 @@ impl<C: ClientContext> Client<C> {
         }
         // XXX(runji): This function exists in librdkafka, but is blocked by rdkafka-sys.
         //             We import it here manually.
-        extern "C" {
+        unsafe extern "C" {
             fn rd_kafka_conf_set_resolve_cb(
                 conf: *mut rdsys::rd_kafka_conf_t,
                 resolve_cb: Option<
@@ -719,7 +719,10 @@ pub(crate) unsafe extern "C" fn native_oauth_refresh_cb<C: ClientContext>(
             let message = match CString::new(e.to_string()) {
                 Ok(message) => message,
                 Err(e) => {
-                    error!("error message generated while refreshing OAuth token has embedded null character: {}", e);
+                    error!(
+                        "error message generated while refreshing OAuth token has embedded null character: {}",
+                        e
+                    );
                     CString::new("error while refreshing OAuth token has embedded null character")
                         .expect("known to be a valid CString")
                 }

--- a/madsim-rdkafka/src/std/config.rs
+++ b/madsim-rdkafka/src/std/config.rs
@@ -33,7 +33,7 @@ use rdkafka_sys::types::*;
 
 use crate::client::ClientContext;
 use crate::error::{IsError, KafkaError, KafkaResult};
-use crate::log::{log_enabled, DEBUG, INFO, WARN};
+use crate::log::{DEBUG, INFO, WARN, log_enabled};
 use crate::util::{ErrBuf, KafkaDrop, NativePtr};
 
 /// The log levels supported by librdkafka.

--- a/madsim-rdkafka/src/std/consumer/base_consumer.rs
+++ b/madsim-rdkafka/src/std/consumer/base_consumer.rs
@@ -24,7 +24,7 @@ use crate::log::trace;
 use crate::message::{BorrowedMessage, Message};
 use crate::metadata::Metadata;
 use crate::topic_partition_list::{Offset, TopicPartitionList};
-use crate::util::{cstr_to_owned, NativePtr, Timeout};
+use crate::util::{NativePtr, Timeout, cstr_to_owned};
 
 pub(crate) unsafe extern "C" fn native_commit_cb<C: ConsumerContext>(
     _conf: *mut RDKafka,

--- a/madsim-rdkafka/src/std/error.rs
+++ b/madsim-rdkafka/src/std/error.rs
@@ -189,16 +189,16 @@ impl fmt::Debug for KafkaError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             KafkaError::AdminOp(err) => write!(f, "KafkaError (Admin operation error: {})", err),
-            KafkaError::AdminOpCreation(ref err) => {
+            KafkaError::AdminOpCreation(err) => {
                 write!(f, "KafkaError (Admin operation creation error: {})", err)
             }
             KafkaError::Canceled => write!(f, "KafkaError (Client dropped)"),
-            KafkaError::ClientConfig(_, ref desc, ref key, ref value) => write!(
+            KafkaError::ClientConfig(_, desc, key, value) => write!(
                 f,
                 "KafkaError (Client config error: {} {} {})",
                 desc, key, value
             ),
-            KafkaError::ClientCreation(ref err) => {
+            KafkaError::ClientCreation(err) => {
                 write!(f, "KafkaError (Client creation error: {})", err)
             }
             KafkaError::ConsumerCommit(err) => {
@@ -224,16 +224,16 @@ impl fmt::Debug for KafkaError {
             KafkaError::Nul(_) => write!(f, "FFI null error"),
             KafkaError::OffsetFetch(err) => write!(f, "KafkaError (Offset fetch error: {})", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "KafkaError (Partition EOF: {})", part_n),
-            KafkaError::PauseResume(ref err) => {
+            KafkaError::PauseResume(err) => {
                 write!(f, "KafkaError (Pause/resume error: {})", err)
             }
-            KafkaError::Rebalance(ref err) => write!(f, "KafkaError (Rebalance error: {})", err),
-            KafkaError::Seek(ref err) => write!(f, "KafkaError (Seek error: {})", err),
+            KafkaError::Rebalance(err) => write!(f, "KafkaError (Rebalance error: {})", err),
+            KafkaError::Seek(err) => write!(f, "KafkaError (Seek error: {})", err),
             KafkaError::SetPartitionOffset(err) => {
                 write!(f, "KafkaError (Set partition offset error: {})", err)
             }
             KafkaError::StoreOffset(err) => write!(f, "KafkaError (Store offset error: {})", err),
-            KafkaError::Subscription(ref err) => {
+            KafkaError::Subscription(err) => {
                 write!(f, "KafkaError (Subscription error: {})", err)
             }
             KafkaError::Transaction(err) => write!(f, "KafkaError (Transaction error: {})", err),
@@ -246,14 +246,14 @@ impl fmt::Display for KafkaError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             KafkaError::AdminOp(err) => write!(f, "Admin operation error: {}", err),
-            KafkaError::AdminOpCreation(ref err) => {
+            KafkaError::AdminOpCreation(err) => {
                 write!(f, "Admin operation creation error: {}", err)
             }
             KafkaError::Canceled => write!(f, "KafkaError (Client dropped)"),
-            KafkaError::ClientConfig(_, ref desc, ref key, ref value) => {
+            KafkaError::ClientConfig(_, desc, key, value) => {
                 write!(f, "Client config error: {} {} {}", desc, key, value)
             }
-            KafkaError::ClientCreation(ref err) => write!(f, "Client creation error: {}", err),
+            KafkaError::ClientCreation(err) => write!(f, "Client creation error: {}", err),
             KafkaError::ConsumerCommit(err) => write!(f, "Consumer commit error: {}", err),
             KafkaError::Flush(err) => write!(f, "Flush error: {}", err),
             KafkaError::Global(err) => write!(f, "Global error: {}", err),
@@ -267,12 +267,12 @@ impl fmt::Display for KafkaError {
             KafkaError::Nul(_) => write!(f, "FFI nul error"),
             KafkaError::OffsetFetch(err) => write!(f, "Offset fetch error: {}", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "Partition EOF: {}", part_n),
-            KafkaError::PauseResume(ref err) => write!(f, "Pause/resume error: {}", err),
-            KafkaError::Rebalance(ref err) => write!(f, "Rebalance error: {}", err),
-            KafkaError::Seek(ref err) => write!(f, "Seek error: {}", err),
+            KafkaError::PauseResume(err) => write!(f, "Pause/resume error: {}", err),
+            KafkaError::Rebalance(err) => write!(f, "Rebalance error: {}", err),
+            KafkaError::Seek(err) => write!(f, "Seek error: {}", err),
             KafkaError::SetPartitionOffset(err) => write!(f, "Set partition offset error: {}", err),
             KafkaError::StoreOffset(err) => write!(f, "Store offset error: {}", err),
-            KafkaError::Subscription(ref err) => write!(f, "Subscription error: {}", err),
+            KafkaError::Subscription(err) => write!(f, "Subscription error: {}", err),
             KafkaError::Transaction(err) => write!(f, "Transaction error: {}", err),
             KafkaError::MockCluster(err) => write!(f, "Mock cluster error: {}", err),
         }

--- a/madsim-rdkafka/src/std/message.rs
+++ b/madsim-rdkafka/src/std/message.rs
@@ -12,7 +12,7 @@ use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
 use crate::error::{IsError, KafkaError, KafkaResult};
-use crate::util::{self, millis_to_epoch, KafkaDrop, NativePtr};
+use crate::util::{self, KafkaDrop, NativePtr, millis_to_epoch};
 
 /// Timestamp of a Kafka message.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/madsim-rdkafka/src/std/mocking.rs
+++ b/madsim-rdkafka/src/std/mocking.rs
@@ -19,11 +19,11 @@ use std::time::Duration;
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
+use crate::ClientContext;
 use crate::client::Client;
 use crate::config::ClientConfig;
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::producer::DefaultProducerContext;
-use crate::ClientContext;
 
 /// Used internally by `MockCluster` to distinguish whether the mock cluster is owned or borrowed.
 ///
@@ -397,10 +397,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::Message;
     use crate::consumer::{Consumer, StreamConsumer};
     use crate::message::ToBytes;
     use crate::producer::{FutureProducer, FutureRecord};
-    use crate::Message;
     use tokio;
 
     use super::*;

--- a/madsim-rdkafka/src/std/producer/base_producer.rs
+++ b/madsim-rdkafka/src/std/producer/base_producer.rs
@@ -48,8 +48,8 @@ use std::os::raw::c_void;
 use std::ptr;
 use std::slice;
 use std::str;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 

--- a/madsim-rdkafka/src/std/topic_partition_list.rs
+++ b/madsim-rdkafka/src/std/topic_partition_list.rs
@@ -439,12 +439,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(tpl.count(), 4);
-        assert!(tpl
-            .set_partition_offset("topic0", 3, Offset::Offset(0))
-            .is_err());
-        assert!(tpl
-            .set_partition_offset("topic3", 0, Offset::Offset(0))
-            .is_err());
+        assert!(
+            tpl.set_partition_offset("topic0", 3, Offset::Offset(0))
+                .is_err()
+        );
+        assert!(
+            tpl.set_partition_offset("topic3", 0, Offset::Offset(0))
+                .is_err()
+        );
 
         let tp0 = tpl.find_partition("topic1", 0).unwrap();
         let tp1 = tpl.find_partition("topic1", 1).unwrap();
@@ -482,9 +484,10 @@ mod tests {
             .unwrap();
         tpl.set_partition_offset("topic1", 3, Offset::Offset(3))
             .unwrap();
-        assert!(tpl
-            .set_partition_offset("topic1", 4, Offset::Offset(2))
-            .is_err());
+        assert!(
+            tpl.set_partition_offset("topic1", 4, Offset::Offset(2))
+                .is_err()
+        );
     }
 
     #[test]

--- a/madsim-rdkafka/tests/test.rs
+++ b/madsim-rdkafka/tests/test.rs
@@ -4,16 +4,16 @@ use futures_util::StreamExt;
 use madsim::net::NetSim;
 use madsim::runtime::Handle;
 use madsim_rdkafka::{
+    ClientConfig, Message, SimBroker, TopicPartitionList,
     admin::*,
     consumer::{BaseConsumer, StreamConsumer},
     producer::{BaseProducer, BaseRecord, FutureProducer, FutureRecord},
-    ClientConfig, Message, SimBroker, TopicPartitionList,
 };
 use std::{
     net::SocketAddr,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };

--- a/madsim-tokio/Cargo.toml
+++ b/madsim-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim-tokio"
 version = "0.2.30"
-edition = "2021"
+edition = "2024"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tokio` simulator on madsim."
 homepage = "https://github.com/madsim-rs/madsim"

--- a/madsim-tonic-build/Cargo.toml
+++ b/madsim-tonic-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim-tonic-build"
 version = "0.5.2+0.12.3"
-edition = "2021"
+edition = "2024"
 authors = [
     "Lucio Franco <luciofranco14@gmail.com>",
     "Runji Wang <wangrunji0408@163.com>",

--- a/madsim-tonic-build/src/lib.rs
+++ b/madsim-tonic-build/src/lib.rs
@@ -12,7 +12,7 @@ mod prost;
 
 #[cfg(feature = "prost")]
 #[cfg_attr(docsrs, doc(cfg(feature = "prost")))]
-pub use prost::{compile_protos, configure, Builder};
+pub use prost::{Builder, compile_protos, configure};
 
 fn naive_snake_case(name: &str) -> String {
     let mut s = String::new();
@@ -20,10 +20,10 @@ fn naive_snake_case(name: &str) -> String {
 
     while let Some(x) = it.next() {
         s.push(x.to_ascii_lowercase());
-        if let Some(y) = it.peek() {
-            if y.is_uppercase() {
-                s.push('_');
-            }
+        if let Some(y) = it.peek()
+            && y.is_uppercase()
+        {
+            s.push('_');
         }
     }
 

--- a/madsim-tonic-build/src/prost.rs
+++ b/madsim-tonic-build/src/prost.rs
@@ -1,4 +1,4 @@
-use super::{client, server, Attributes};
+use super::{Attributes, client, server};
 use proc_macro2::TokenStream;
 use prost_build::{Config, Method, Service};
 use quote::ToTokens;

--- a/madsim-tonic/Cargo.toml
+++ b/madsim-tonic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim-tonic"
 version = "0.5.2+0.12.0"
-edition = "2021"
+edition = "2024"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "The `tonic` simulator on madsim."
 homepage = "https://github.com/madsim-rs/madsim"

--- a/madsim-tonic/src/client.rs
+++ b/madsim-tonic/src/client.rs
@@ -3,15 +3,15 @@
 use std::future::Future;
 use std::time::Duration;
 
-use futures_util::{pin_mut, Stream, StreamExt};
+use futures_util::{Stream, StreamExt, pin_mut};
 use tonic::codegen::http::uri::PathAndQuery;
 use tracing::{debug, instrument};
 
 use crate::{
+    Request, Response, Status, Streaming,
     codegen::{BoxMessage, IdentityInterceptor, RequestExt},
     service::Interceptor,
     sim::AppendMetadata,
-    Request, Response, Status, Streaming,
 };
 
 #[derive(Debug, Clone)]

--- a/madsim-tonic/src/codec.rs
+++ b/madsim-tonic/src/codec.rs
@@ -1,4 +1,4 @@
-use crate::{codegen::BoxMessage, Status};
+use crate::{Status, codegen::BoxMessage};
 use async_stream::try_stream;
 use futures_util::{Stream, StreamExt};
 use madsim::task::JoinHandle;

--- a/madsim-tonic/src/sim.rs
+++ b/madsim-tonic/src/sim.rs
@@ -1,7 +1,7 @@
 pub use self::codec::Streaming;
 pub use tonic::{
-    body, metadata, service, Code, Extensions, IntoRequest, IntoStreamingRequest, Request,
-    Response, Status,
+    Code, Extensions, IntoRequest, IntoStreamingRequest, Request, Response, Status, body, metadata,
+    service,
 };
 
 #[macro_export]
@@ -48,7 +48,7 @@ pub mod codegen {
     use std::any::Any;
     pub use std::net::SocketAddr;
     use std::time::Duration;
-    use tonic::{service::Interceptor, Request, Status};
+    use tonic::{Request, Status, service::Interceptor};
 
     pub use futures_util as futures;
     pub use tonic::codegen::*;

--- a/madsim-tonic/src/transport/channel.rs
+++ b/madsim-tonic/src/transport/channel.rs
@@ -12,7 +12,7 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 #[cfg(any(
     feature = "tls-native-roots",
     feature = "tls-webpki-roots",
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 ))]
 use tonic::transport::ClientTlsConfig;
 use tonic::{
-    codegen::{http::HeaderValue, Bytes, StdError},
+    codegen::{Bytes, StdError, http::HeaderValue},
     transport::Uri,
 };
 use tower::discover::Change;

--- a/madsim-tonic/src/transport/server.rs
+++ b/madsim-tonic/src/transport/server.rs
@@ -6,16 +6,16 @@ use crate::sim::AppendMetadata;
 use crate::tower::layer::util::{Identity, Stack};
 use crate::{Request, Response, Status};
 use async_stream::try_stream;
-use futures_util::{future::poll_fn, select_biased, FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, future::poll_fn, select_biased};
 use madsim::net::Endpoint;
 use std::{
     collections::HashMap,
-    future::{pending, Future},
+    future::{Future, pending},
     marker::PhantomData,
     net::SocketAddr,
     time::Duration,
 };
-use tonic::codegen::{http::uri::PathAndQuery, BoxFuture, Service};
+use tonic::codegen::{BoxFuture, Service, http::uri::PathAndQuery};
 #[cfg(any(
     feature = "tls-native-roots",
     feature = "tls-webpki-roots",

--- a/madsim/Cargo.toml
+++ b/madsim/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "madsim"
 version = "0.2.34"
-edition = "2021"
+edition = "2024"
 authors = ["Runji Wang <wangrunji0408@163.com>"]
 description = "Deterministic Simulator for distributed systems."
 readme = "../README.md"

--- a/madsim/benches/rpc.rs
+++ b/madsim/benches/rpc.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use criterion::*;
-use madsim::{net::Endpoint, Request};
+use madsim::{Request, net::Endpoint};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Request)]

--- a/madsim/examples/erpc.rs
+++ b/madsim/examples/erpc.rs
@@ -1,9 +1,10 @@
 use bytes::Buf;
 use madsim::{
-    net::{rpc::Request, Endpoint},
-    task, Request,
+    Request,
+    net::{Endpoint, rpc::Request},
+    task,
 };
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{Rng, distributions::Alphanumeric};
 use serde::{Deserialize, Serialize};
 use std::{io::IoSlice, net::SocketAddr};
 use structopt::StructOpt;

--- a/madsim/examples/rpc.rs
+++ b/madsim/examples/rpc.rs
@@ -1,4 +1,4 @@
-use madsim::{net::Endpoint, Request};
+use madsim::{Request, net::Endpoint};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Request)]

--- a/madsim/src/lib.rs
+++ b/madsim/src/lib.rs
@@ -6,10 +6,12 @@
 //! - `macros`: Enables `#[madsim::main]` and `#[madsim::test]` macros.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+// Allow Rust 2024's stricter unsafe-in-unsafe-fn rules (temporary fix)
+#![allow(unsafe_op_in_unsafe_fn)]
 
 #[cfg(all(feature = "rpc", feature = "macros"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "rpc", feature = "macros"))))]
-pub use madsim_macros::{service, Request};
+pub use madsim_macros::{Request, service};
 
 #[cfg(madsim)]
 mod sim;

--- a/madsim/src/sim/fs.rs
+++ b/madsim/src/sim/fs.rs
@@ -11,11 +11,11 @@ use std::{
 use tracing::*;
 
 use crate::{
-    plugin::{node, simulator, Simulator},
+    Config,
+    plugin::{Simulator, node, simulator},
     rand::GlobalRng,
     task::NodeId,
     time::TimeHandle,
-    Config,
 };
 
 /// File system simulator.

--- a/madsim/src/sim/net/endpoint.rs
+++ b/madsim/src/sim/net/endpoint.rs
@@ -138,11 +138,23 @@ impl Endpoint {
     /// It is provided for use by other simulators.
     #[cfg_attr(docsrs, doc(cfg(madsim)))]
     pub async fn recv_from_raw(&self, tag: u64) -> io::Result<(Payload, SocketAddr)> {
+        // rand_delay BEFORE consuming from mailbox. This is critical: if this
+        // future is cancelled during the delay (e.g., by a timeout), no message
+        // has been consumed yet, so nothing is lost. Previously the delay was
+        // after consuming, which caused message loss when cancellation happened
+        // during the delay — the message was taken from the mailbox but dropped
+        // with the cancelled future.
+        self.guard.net.rand_delay().await?;
+
         let recver = self.socket.mailbox.lock().recv(tag);
-        let msg = recver
+        // Wrap the receiver in a guard that recovers messages on cancellation.
+        // If the delivery and timeout fire at the same simulated tick, the guard
+        // ensures the message is put back into the mailbox instead of being lost.
+        let mut guard = RecvGuard::new(recver, self.socket.clone());
+        let msg = Pin::new(&mut guard.rx)
             .await
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "network is down"))?;
-        self.guard.net.rand_delay().await?;
+        guard.consumed = true;
 
         trace!("recv: {} <- {}, tag={}", self.guard.addr, msg.from, msg.tag);
         Ok((msg.data, msg.from))
@@ -359,6 +371,42 @@ impl Mailbox {
             self.registered.push((tag, tx));
         }
         rx
+    }
+}
+
+/// Guard that recovers messages from a oneshot receiver when dropped due to
+/// cancellation (e.g. timeout). Without this, a race condition in simulated time
+/// can lose messages: the delivery timer and recv timeout fire at the same tick,
+/// the oneshot send succeeds, then the timeout drops the receiver before the
+/// message is consumed.
+/// Guard that recovers messages from a oneshot receiver when dropped due to
+/// cancellation (e.g. timeout). Without this, a race condition in simulated time
+/// can lose messages: the delivery timer and recv timeout fire at the same tick,
+/// the oneshot send succeeds, then the timeout drops the receiver before the
+/// message is consumed.
+struct RecvGuard {
+    rx: oneshot::Receiver<Message>,
+    socket: Arc<EndpointSocket>,
+    consumed: bool,
+}
+
+impl RecvGuard {
+    fn new(rx: oneshot::Receiver<Message>, socket: Arc<EndpointSocket>) -> Self {
+        RecvGuard {
+            rx,
+            socket,
+            consumed: false,
+        }
+    }
+}
+
+impl Drop for RecvGuard {
+    fn drop(&mut self) {
+        if !self.consumed {
+            if let Ok(msg) = self.rx.try_recv() {
+                self.socket.mailbox.lock().msgs.push(msg);
+            }
+        }
     }
 }
 

--- a/madsim/src/sim/net/mod.rs
+++ b/madsim/src/sim/net/mod.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use bytes::Bytes;
-use futures_util::{stream::BoxStream, StreamExt};
+use futures_util::{StreamExt, stream::BoxStream};
 use spin::Mutex;
 use std::{
     any::Any,
@@ -54,7 +54,7 @@ use crate::{
     plugin,
     rand::{GlobalRng, Rng},
     task::{NodeId, NodeInfo, Spawner},
-    time::{sleep, sleep_until, Duration, TimeHandle},
+    time::{Duration, TimeHandle, sleep, sleep_until},
 };
 
 mod addr;
@@ -69,7 +69,7 @@ pub mod tcp;
 mod udp;
 pub mod unix;
 
-pub use self::addr::{lookup_host, ToSocketAddrs};
+pub use self::addr::{ToSocketAddrs, lookup_host};
 use self::dns::DnsServer;
 pub use self::endpoint::{Endpoint, Receiver, Sender};
 use self::ipvs::{IpVirtualServer, ServiceAddr};
@@ -315,9 +315,8 @@ impl NetSim {
         {
             dst = addr.parse().expect("invalid socket address");
         }
-        if let Some((ip, dst_node, socket, latency)) =
-            self.network.lock().try_send(node, dst, protocol)
-        {
+        let try_result = self.network.lock().try_send(node, dst, protocol);
+        if let Some((ip, dst_node, socket, latency)) = try_result {
             trace!(?latency, "delay");
             let hook = self.hooks_rsp.lock().get(&dst_node).cloned();
             self.time.add_timer(latency, move || {
@@ -466,7 +465,7 @@ impl BindGuard {
                         node,
                         addr,
                         protocol,
-                    })
+                    });
                 }
                 Err(e) => last_err = Some(e),
             }

--- a/madsim/src/sim/net/network.rs
+++ b/madsim/src/sim/net/network.rs
@@ -3,7 +3,7 @@ use crate::{rand::*, task::NodeId};
 use serde::{Deserialize, Serialize};
 use std::{
     any::Any,
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     hash::{Hash, Hasher},
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -240,7 +240,7 @@ impl Network {
                 return Err(io::Error::new(
                     io::ErrorKind::AddrInUse,
                     format!("address already in use: {addr}"),
-                ))
+                ));
             }
             Entry::Vacant(o) => {
                 o.insert(socket);

--- a/madsim/src/sim/net/rpc.rs
+++ b/madsim/src/sim/net/rpc.rs
@@ -66,7 +66,7 @@ use crate::rand::random;
 pub use bytes::Bytes;
 use futures_util::FutureExt;
 #[doc(no_inline)]
-pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
+pub use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::future::Future;
 
 /// A RPC request.

--- a/madsim/src/sim/net/tcp/mod.rs
+++ b/madsim/src/sim/net/tcp/mod.rs
@@ -58,7 +58,7 @@ pub use self::stream::*;
 mod tests {
     use super::*;
     use crate::{
-        net::{ipvs::*, NetSim},
+        net::{NetSim, ipvs::*},
         plugin,
         runtime::Runtime,
         time::timeout,

--- a/madsim/src/sim/net/udp.rs
+++ b/madsim/src/sim/net/udp.rs
@@ -3,7 +3,7 @@ use std::io::Result;
 use std::net::SocketAddr;
 use tracing::instrument;
 
-use super::{lookup_host, Endpoint, ToSocketAddrs};
+use super::{Endpoint, ToSocketAddrs, lookup_host};
 
 /// A UDP socket.
 pub struct UdpSocket {

--- a/madsim/src/sim/plugin.rs
+++ b/madsim/src/sim/plugin.rs
@@ -5,13 +5,13 @@ use std::{
     sync::Arc,
 };
 
-use downcast_rs::{impl_downcast, DowncastSync};
+use downcast_rs::{DowncastSync, impl_downcast};
 
 use crate::{
+    Config,
     rand::GlobalRng,
     task::{NodeId, Spawner},
     time::TimeHandle,
-    Config,
 };
 
 /// Simulator

--- a/madsim/src/sim/rand.rs
+++ b/madsim/src/sim/rand.rs
@@ -10,7 +10,7 @@ use std::cell::Cell;
 use std::sync::Arc;
 
 #[doc(no_inline)]
-pub use rand::{distributions, seq, CryptoRng, Error, Fill, Rng, RngCore, SeedableRng};
+pub use rand::{CryptoRng, Error, Fill, Rng, RngCore, SeedableRng, distributions, seq};
 
 /// Convenience re-export of common members
 pub mod prelude {
@@ -70,7 +70,7 @@ impl GlobalRng {
             fn hash_u128(x: u128) -> u8 {
                 x.to_ne_bytes().iter().fold(0, |a, b| a ^ b)
             }
-            let v = lock.rng.clone().gen::<u8>() ^ hash_u128(t.unwrap_or_default().as_nanos());
+            let v = lock.rng.clone().r#gen::<u8>() ^ hash_u128(t.unwrap_or_default().as_nanos());
             if let Some(log) = &mut lock.log {
                 log.push(v);
             }
@@ -163,7 +163,7 @@ pub fn random<T>() -> T
 where
     Standard: Distribution<T>,
 {
-    thread_rng().gen()
+    thread_rng().r#gen()
 }
 
 /// Random log for determinism check.
@@ -192,7 +192,7 @@ thread_local! {
 /// Input must be a valid buffer.
 ///
 /// Ref: <https://man7.org/linux/man-pages/man2/getrandom.2.html>
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn getrandom(buf: *mut u8, buflen: usize, _flags: u32) -> isize {
     if let Some(seed) = SEED.with(|s| s.get()) {
@@ -247,7 +247,7 @@ unsafe extern "C" fn getrandom(buf: *mut u8, buflen: usize, _flags: u32) -> isiz
 /// Input must be a valid buffer.
 ///
 /// Ref: <https://man7.org/linux/man-pages/man3/getentropy.3.html>
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn getentropy(buf: *mut u8, buflen: usize) -> i32 {
     if buflen > 256 {
@@ -273,7 +273,7 @@ unsafe extern "C" fn getentropy(buf: *mut u8, buflen: usize) -> i32 {
 /// - <https://github.com/apple-oss-distributions/CommonCrypto/blob/a0ac082c490b65585ade764511acfdbf1d97bc5e/include/CommonRandom.h#L56>
 /// - <https://github.com/apple-oss-distributions/CommonCrypto/blob/0c0a068edd73f84671f1fba8c0e171caa114ee0a/lib/CommonRandom.c#L65-L85>
 #[cfg(target_os = "macos")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn CCRandomGenerateBytes(bytes: *mut u8, count: usize) -> i32 {
     match getrandom(bytes, count, 0) {

--- a/madsim/src/sim/runtime/builder.rs
+++ b/madsim/src/sim/runtime/builder.rs
@@ -1,5 +1,5 @@
 use super::{Config, Runtime};
-use futures_util::{stream, StreamExt};
+use futures_util::{StreamExt, stream};
 use std::future::Future;
 use std::time::{Duration, SystemTime};
 

--- a/madsim/src/sim/signal.rs
+++ b/madsim/src/sim/signal.rs
@@ -15,8 +15,8 @@ mod tests {
     };
     use futures_util::future::pending;
     use std::sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     };
     use std::time::Duration;
 

--- a/madsim/src/sim/task/mod.rs
+++ b/madsim/src/sim/task/mod.rs
@@ -18,14 +18,14 @@ use std::{
     panic::Location,
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     task::{Context, Poll, Waker},
     time::{Duration, Instant},
 };
 use tokio::sync::watch;
-use tracing::{debug, error, error_span, trace, Span};
+use tracing::{Span, debug, error, error_span, trace};
 
 pub use tokio::task::yield_now;
 
@@ -714,7 +714,7 @@ impl fmt::Display for Id {
 /// For `std::thread::available_parallelism` on Linux.
 ///
 /// Ref: <https://man7.org/linux/man-pages/man2/sched_setaffinity.2.html>
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 #[cfg(target_os = "linux")]
 unsafe extern "C" fn sched_getaffinity(
@@ -747,7 +747,7 @@ unsafe extern "C" fn sched_getaffinity(
 /// For `std::thread::available_parallelism` on macOS.
 ///
 /// Ref: <https://man7.org/linux/man-pages/man3/sysconf.3.html>
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn sysconf(name: libc::c_int) -> libc::c_long {
     if name == libc::_SC_NPROCESSORS_ONLN {
@@ -766,7 +766,7 @@ unsafe extern "C" fn sysconf(name: libc::c_int) -> libc::c_long {
 }
 
 /// Forbid creating system thread in simulation.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn pthread_attr_init(attr: *mut libc::pthread_attr_t) -> libc::c_int {
     if let Some(allowed) = crate::context::try_current(|h| h.allow_system_thread) {
@@ -777,7 +777,9 @@ unsafe extern "C" fn pthread_attr_init(attr: *mut libc::pthread_attr_t) -> libc:
         } else {
             eprintln!("attempt to spawn a system thread in simulation.");
             eprintln!("note: try to use tokio tasks instead.");
-            eprintln!("note: if you really need to spawn a system thread, set the environment variable `MADSIM_ALLOW_SYSTEM_THREAD` to `1`.");
+            eprintln!(
+                "note: if you really need to spawn a system thread, set the environment variable `MADSIM_ALLOW_SYSTEM_THREAD` to `1`."
+            );
             return -1;
         }
     }
@@ -794,7 +796,7 @@ unsafe extern "C" fn pthread_attr_init(attr: *mut libc::pthread_attr_t) -> libc:
 /// Override `gethostname` to return the node name, if specified.
 ///
 /// Ref: <https://man7.org/linux/man-pages/man2/gethostname.2.html>
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn gethostname(name: *mut libc::c_char, size: libc::size_t) -> libc::c_int {
     if let Some(info) = crate::context::try_current_task() {
@@ -841,7 +843,7 @@ mod tests {
     use super::*;
     use crate::{
         context::{current, current_node},
-        runtime::{init_logger, Handle, Runtime},
+        runtime::{Handle, Runtime, init_logger},
         time,
     };
     use std::{collections::HashSet, ffi::OsStr, sync::atomic::AtomicUsize, time::Duration};

--- a/madsim/src/sim/time/interval.rs
+++ b/madsim/src/sim/time/interval.rs
@@ -26,7 +26,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
  */
 
-use crate::time::{sleep_until, Duration, Instant, Sleep};
+use crate::time::{Duration, Instant, Sleep, sleep_until};
 use futures_util::future::poll_fn;
 use futures_util::ready;
 

--- a/madsim/src/sim/time/mod.rs
+++ b/madsim/src/sim/time/mod.rs
@@ -3,7 +3,7 @@
 //!
 
 use crate::rand::{GlobalRng, Rng};
-use futures_util::{select_biased, FutureExt};
+use futures_util::{FutureExt, select_biased};
 use naive_timer::Timer;
 use spin::Mutex;
 #[doc(no_inline)]
@@ -15,8 +15,8 @@ mod interval;
 mod sleep;
 mod system_time;
 
-pub use self::interval::{interval, interval_at, Interval, MissedTickBehavior};
-pub use self::sleep::{sleep, sleep_until, Sleep};
+pub use self::interval::{Interval, MissedTickBehavior, interval, interval_at};
+pub use self::sleep::{Sleep, sleep, sleep_until};
 
 pub(crate) struct TimeRuntime {
     handle: TimeHandle,

--- a/madsim/src/sim/time/mod.rs
+++ b/madsim/src/sim/time/mod.rs
@@ -175,7 +175,13 @@ pub fn timeout<T: Future>(
     future: T,
 ) -> impl Future<Output = Result<T::Output, error::Elapsed>> {
     let handle = TimeHandle::current();
-    handle.timeout(duration, future)
+    let timeout = handle.sleep(duration);
+    async move {
+        futures_util::select_biased! {
+            res = future.fuse() => Ok(res),
+            _ = timeout.fuse() => Err(error::Elapsed),
+        }
+    }
 }
 
 /// Require a `Future` to complete before the specified instant in time.
@@ -184,7 +190,13 @@ pub fn timeout_at<T: Future>(
     future: T,
 ) -> impl Future<Output = Result<T::Output, error::Elapsed>> {
     let handle = TimeHandle::current();
-    handle.timeout_at(deadline, future)
+    let timeout = handle.sleep_until(deadline);
+    async move {
+        futures_util::select_biased! {
+            res = future.fuse() => Ok(res),
+            _ = timeout.fuse() => Err(error::Elapsed),
+        }
+    }
 }
 
 /// Advances time.

--- a/madsim/src/sim/time/system_time.rs
+++ b/madsim/src/sim/time/system_time.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 /// Override the libc `gettimeofday` function. For `SystemTime` on macOS.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn gettimeofday(tp: *mut libc::timeval, tz: *mut libc::c_void) -> libc::c_int {
     // NOTE: tz should be NULL.
@@ -39,7 +39,7 @@ unsafe extern "C" fn gettimeofday(tp: *mut libc::timeval, tz: *mut libc::c_void)
 
 /// Override the libc `clock_gettime` function.
 /// For Linux, ARM64 macOS (since 1.67) and x86_64 macOS (since 1.75).
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 unsafe extern "C" fn clock_gettime(
     clockid: libc::clockid_t,
@@ -88,7 +88,7 @@ unsafe extern "C" fn clock_gettime(
 }
 
 /// Override the `mach_absolute_time` function. For `Instant` on macOS before Rust 1.75.
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[inline(never)]
 #[cfg(target_os = "macos")]
 // not used on ARM64 macOS after https://github.com/rust-lang/rust/pull/103594

--- a/madsim/src/std/net/rpc.rs
+++ b/madsim/src/std/net/rpc.rs
@@ -61,7 +61,7 @@ pub use bytes::Bytes;
 use futures_util::FutureExt;
 use rand::Rng;
 #[doc(no_inline)]
-pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
+pub use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{
     any::Any,
     future::Future,
@@ -119,7 +119,7 @@ impl Endpoint {
         data: &[u8],
     ) -> io::Result<(R::Response, Bytes)> {
         let req_tag = R::ID;
-        let rsp_tag = rand::thread_rng().gen::<u64>();
+        let rsp_tag = rand::thread_rng().r#gen::<u64>();
         let rsp_tag_buf = rsp_tag.to_be_bytes();
         let req = bincode::serialize(&request).unwrap();
         let req_len_buf = (req.len() as u32).to_be_bytes();

--- a/madsim/src/std/net/tcp.rs
+++ b/madsim/src/std/net/tcp.rs
@@ -4,17 +4,17 @@ use crate::task;
 use bytes::{Buf, Bytes};
 use futures_util::StreamExt;
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     io::{self, IoSlice},
     net::SocketAddr,
     sync::{Arc, Mutex, RwLock},
 };
 use tokio::{
     io::AsyncWriteExt,
-    net::{lookup_host, TcpListener, TcpStream, ToSocketAddrs},
+    net::{TcpListener, TcpStream, ToSocketAddrs, lookup_host},
     sync::{mpsc, oneshot},
 };
-use tokio_util::codec::{length_delimited::LengthDelimitedCodec, FramedRead};
+use tokio_util::codec::{FramedRead, length_delimited::LengthDelimitedCodec};
 use tracing::*;
 
 /// An endpoint.

--- a/madsim/src/std/time.rs
+++ b/madsim/src/std/time.rs
@@ -1,3 +1,3 @@
 //! Utilities for tracking time.
 
-pub use tokio::time::{error, sleep, sleep_until, timeout, Duration, Instant};
+pub use tokio::time::{Duration, Instant, error, sleep, sleep_until, timeout};

--- a/tonic-example/Cargo.toml
+++ b/tonic-example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tonic-example"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/tonic-example/src/bin/client.rs
+++ b/tonic-example/src/bin/client.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use async_stream::stream;
 use madsim::time::sleep;
 
-use tonic_example::hello_world::greeter_client::GreeterClient;
 use tonic_example::hello_world::HelloRequest;
+use tonic_example::hello_world::greeter_client::GreeterClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tonic-example/src/bin/server.rs
+++ b/tonic-example/src/bin/server.rs
@@ -1,8 +1,8 @@
 use tonic::transport::Server;
+use tonic_example::MyGreeter;
 use tonic_example::hello_world::{
     another_greeter_server::AnotherGreeterServer, greeter_server::GreeterServer,
 };
-use tonic_example::MyGreeter;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/tonic-example/tests/test.rs
+++ b/tonic-example/tests/test.rs
@@ -4,7 +4,7 @@ use async_stream::stream;
 use futures_core::Stream;
 use madsim::{
     net::NetSim,
-    rand::{thread_rng, Rng},
+    rand::{Rng, thread_rng},
     runtime::Handle,
     time::sleep,
 };
@@ -13,11 +13,12 @@ use std::{
     time::{Duration, Instant},
 };
 use tonic::transport::{Endpoint, Server};
-use tonic_example::hello_world::{
-    another_greeter_client::AnotherGreeterClient, another_greeter_server::AnotherGreeterServer,
-    greeter_client::GreeterClient, greeter_server::GreeterServer, HelloRequest,
-};
 use tonic_example::MyGreeter;
+use tonic_example::hello_world::{
+    HelloRequest, another_greeter_client::AnotherGreeterClient,
+    another_greeter_server::AnotherGreeterServer, greeter_client::GreeterClient,
+    greeter_server::GreeterServer,
+};
 
 #[madsim::test]
 async fn basic() {


### PR DESCRIPTION
I'm using madsim in a project that uses 2024 edition, and was therefore hindered by the current 2021-only support. The changes are small but span loads of different files. I've intentionally tried to avoid formatting the code according to 2024 edition rules, mostly to keep the PR somewhat limited. I have not checked for 2021 compatibility.

Secondly, using my fork in my project I believe I stumbled across a bug as well, leading to tests not completing. It turned out to be a race condition in message handling. The fix made my tests always end with a result instead of possibly hanging. I made a separate commit for this change, but I realise now that maybe I should have done a second PR with this fix instead. I can split it if you prefer.

This entire 2024 edition move and bugfix has been generated by Claude, including the split into separate commits.