### PR TITLE
chore: use default-https-client for aws sdk defaults in madsim-aws-sdk-s3

### DIFF
--- a/madsim-aws-sdk-s3/Cargo.toml
+++ b/madsim-aws-sdk-s3/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-s3 = { version = "1", default-features = false, features = ["http-1x", "sigv4a"] }
+aws-sdk-s3 = { version = "1", default-features = false }
 
 [target.'cfg(madsim)'.dependencies]
 madsim = { version = "0.2.15", path = "../madsim" }
@@ -28,11 +28,12 @@ spin = "0.9"
 tracing = "0.1"
 
 [features]
-# Keep the public `rustls` feature name for compatibility, but use the AWS SDK's
-# newer default HTTPS client stack instead of the legacy hyper 0.14 path.
-rustls = ["aws-sdk-s3/default-https-client"]
+default-https-client = ["aws-sdk-s3/default-https-client"]
+http-1x = ["aws-sdk-s3/http-1x"]
 rt-tokio = ["aws-sdk-s3/rt-tokio"]
-default = ["rustls", "rt-tokio"]
+rustls = ["aws-sdk-s3/rustls"]
+sigv4a = ["aws-sdk-s3/sigv4a"]
+default = ["default-https-client", "http-1x", "rt-tokio", "sigv4a"]
 
 [lints]
 workspace = true

--- a/madsim-aws-sdk-s3/Cargo.toml
+++ b/madsim-aws-sdk-s3/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-s3 = "1"
+aws-sdk-s3 = { version = "1", default-features = false, features = ["http-1x", "sigv4a"] }
 
 [target.'cfg(madsim)'.dependencies]
 madsim = { version = "0.2.15", path = "../madsim" }
@@ -28,7 +28,9 @@ spin = "0.9"
 tracing = "0.1"
 
 [features]
-rustls = ["aws-sdk-s3/rustls"]
+# Keep the public `rustls` feature name for compatibility, but use the AWS SDK's
+# newer default HTTPS client stack instead of the legacy hyper 0.14 path.
+rustls = ["aws-sdk-s3/default-https-client"]
 rt-tokio = ["aws-sdk-s3/rt-tokio"]
 default = ["rustls", "rt-tokio"]
 

--- a/madsim-aws-sdk-s3/README.md
+++ b/madsim-aws-sdk-s3/README.md
@@ -12,3 +12,6 @@ Replace all `aws-sdk-s3` entries in your Cargo.toml:
 [dependencies]
 aws-sdk-s3 = { version = "0.5", package = "madsim-aws-sdk-s3" }
 ```
+
+The crate's default TLS path uses the AWS SDK's `default-https-client` stack rather
+than the legacy `aws-sdk-s3/rustls` compatibility feature.

--- a/madsim-aws-sdk-s3/README.md
+++ b/madsim-aws-sdk-s3/README.md
@@ -15,3 +15,7 @@ aws-sdk-s3 = { version = "0.5", package = "madsim-aws-sdk-s3" }
 
 The crate's default TLS path uses the AWS SDK's `default-https-client` stack rather
 than the legacy `aws-sdk-s3/rustls` compatibility feature.
+
+The public feature names now follow the upstream `aws-sdk-s3` crate. In particular,
+`default-https-client` and `rustls` keep the same meaning as upstream, while this
+crate's default feature set prefers `default-https-client`.

--- a/madsim-aws-sdk-s3/README.md
+++ b/madsim-aws-sdk-s3/README.md
@@ -13,9 +13,9 @@ Replace all `aws-sdk-s3` entries in your Cargo.toml:
 aws-sdk-s3 = { version = "0.5", package = "madsim-aws-sdk-s3" }
 ```
 
-The crate's default TLS path uses the AWS SDK's `default-https-client` stack rather
-than the legacy `aws-sdk-s3/rustls` compatibility feature.
+By default, this crate enables `default-https-client`, `http-1x`, `rt-tokio`, and
+`sigv4a`.
 
-The public feature names now follow the upstream `aws-sdk-s3` crate. In particular,
+Its public feature names follow the upstream `aws-sdk-s3` crate. In particular,
 `default-https-client` and `rustls` keep the same meaning as upstream, while this
 crate's default feature set prefers `default-https-client`.


### PR DESCRIPTION
# Description

Switch `madsim-aws-sdk-s3` to prefer `default-https-client` in its default AWS SDK feature set, and align wrapper feature names with upstream `aws-sdk-s3`.

This avoids the legacy hyper 0.14 stack in the default configuration.

AWS SDK announcement: https://github.com/awslabs/aws-sdk-rust/discussions/1257