### PR TITLE
Avoid unwrap when returning added partition

### DIFF
--- a/madsim-rdkafka/src/sim/topic_partition_list.rs
+++ b/madsim-rdkafka/src/sim/topic_partition_list.rs
@@ -59,13 +59,14 @@ impl TopicPartitionList {
         topic: &str,
         partition: i32,
     ) -> TopicPartitionListElem<'a> {
+        let index = self.list.len();
         self.list.push(Elem {
             topic: topic.into(),
             partition,
             offset: Offset::Invalid,
         });
         TopicPartitionListElem {
-            e: self.list.last().unwrap(),
+            e: &self.list[index],
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid calling `last().unwrap()` after appending to the simulated `TopicPartitionList`
- record the insertion index before `push`, then return a reference to `self.list[index]`
- keeps the existing behavior of returning the newly added partition element while removing an unnecessary unwrap from the path

## Rationale
The vector length before insertion is exactly the index of the element being appended. After `push`, indexing at that saved position refers to the newly inserted element, so this preserves behavior without relying on `last().unwrap()`.

## Testing
- `cargo test` — 25 passed, 8 ignored
